### PR TITLE
close #KLI-33 GitHub Actionsにおけるclang-format実行コマンドの修正

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,56 +7,56 @@
 
 Language: Cpp
 AccessModifierOffset: -1
-AlignAfterOpenBracket:  Align
+AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlinesLeft: true
-AlignOperands:  true
-AlignTrailingComments:  true
+AlignOperands: true
+AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine:  false
-AllowShortCaseLabelsOnASingleLine:  false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings:  false
-AlwaysBreakTemplateDeclarations:  true
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
-BinPackParameters:  true
+BinPackParameters: true
 BraceWrapping:
-  AfterClass:  false
-  AfterControlStatement:  false
-  AfterEnum:  false
-  AfterFunction:  true
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
   AfterNamespace: false
   AfterObjCDeclaration: false
-  AfterStruct:  false
+  AfterStruct: false
   AfterUnion: false
-  BeforeCatch:  false
+  BeforeCatch: false
   BeforeElse: false
   IndentBraces: false
 BreakBeforeBinaryOperators: All
-BreakBeforeBraces:  Custom
-BreakBeforeTernaryOperators:  true
-BreakConstructorInitializersBeforeComma:  false
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
 BreakAfterJavaFieldAnnotations: false
-BreakStringLiterals:  true
-ColumnLimit:  100
+BreakStringLiterals: true
+ColumnLimit: 100
 CommentPragmas: '\*'
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 2
-ContinuationIndentWidth:  4
+ContinuationIndentWidth: 4
 Cpp11BracedListStyle: false
 DerivePointerAlignment: false
 DisableFormat: false
 IndentCaseLabels: true
-IndentWidth:  2
+IndentWidth: 2
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: false
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: All
-PenaltyBreakComment:  300
+PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
@@ -67,11 +67,11 @@ SortIncludes: false
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: Never
-SpaceInEmptyParentheses:  false
+SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
 SpacesInAngles: false
-SpacesInCStyleCastParentheses:  false
-SpacesInParentheses:  false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard: Cpp11
 TabWidth: 4

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -6,11 +6,11 @@ jobs:
   format-check:
     runs-on: ubuntu-20.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Install clang-format
-      run: sudo apt-get -y install clang-format
+      - name: Install clang-format
+        run: sudo apt-get -y install clang-format
 
-    - name: Format 
-      run: find ./test ./module -type f -name "*.cpp" -o -name "*.h" | xargs clang-format --dry-run --Werror *.h *.cpp
+      - name: Format
+        run: find ./test ./module -type f -name "\*.cpp" -o -name "\*.h" | xargs clang-format --dry-run --Werror

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -14,7 +14,7 @@ jobs:
 
       # 実行コマンドを変更 2024/05/30 YKhm20020
       # 旧コマンド: find ./test ./module -type f -name "*.cpp" -o -name "*.h" | xargs clang-format --dry-run --Werror *.h *.cpp
+      # --Werror の後は拡張子を指定する必要ない？
       # 参考: https://www.turtlestoffel.com/Clang-Format, https://github.com/vllm-project/vllm/blob/main/.github/workflows/clang-format.yml, https://community.cesium.com/t/ci-cd-deployment-issues/28272
       - name: Format
-        # run: find ./test ./module -type f -name "\*.cpp" -o -name "\*.h" | xargs clang-format --dry-run --Werror
-        run: find ./test ./module -type f -name "*.cpp" -o -name "*.h" | xargs clang-format --dry-run --Werror "*.h" "*.cpp"
+        run: find ./test ./module -type f -name "\*.cpp" -o -name "\*.h" | xargs clang-format --dry-run --Werror

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -12,5 +12,9 @@ jobs:
       - name: Install clang-format
         run: sudo apt-get -y install clang-format
 
+      # 実行コマンドを変更 2024/05/30 YKhm20020
+      # 旧コマンド: find ./test ./module -type f -name "*.cpp" -o -name "*.h" | xargs clang-format --dry-run --Werror *.h *.cpp
+      # 参考: https://www.turtlestoffel.com/Clang-Format, https://github.com/vllm-project/vllm/blob/main/.github/workflows/clang-format.yml, https://community.cesium.com/t/ci-cd-deployment-issues/28272
       - name: Format
-        run: find ./test ./module -type f -name "\*.cpp" -o -name "\*.h" | xargs clang-format --dry-run --Werror
+        # run: find ./test ./module -type f -name "\*.cpp" -o -name "\*.h" | xargs clang-format --dry-run --Werror
+        run: find ./test ./module -type f -name "*.cpp" -o -name "*.h" | xargs clang-format --dry-run --Werror "*.h" "*.cpp"

--- a/module/API/Measurer.cpp
+++ b/module/API/Measurer.cpp
@@ -1,0 +1,88 @@
+/**
+ * @file Measurer.cpp
+ * @brief 計測に用いる関数をまとめたラッパークラス
+ * @author keiya121
+ */
+
+#include "Measurer.h"
+
+Measurer::Measurer()
+  : colorSensor(PORT_2),
+    sonarSensor(PORT_3),
+    leftWheel(PORT_C),
+    rightWheel(PORT_B),
+    armMotor(PORT_A)
+{
+}
+
+// 明るさを取得
+// 参考: https://tomari.org/main/java/color/ccal.html
+int Measurer::getBrightness()
+{
+  // RGBモードと光センサモードを併用すると動作が悪くなるためRGBモードで取得する
+  // 参考: https://qiita.com/kawanon868/items/5d52eb291c3f71af0419
+  rgb_raw_t rgb = getRawColor();
+  int brightness = std::max({ rgb.r, rgb.g, rgb.b }) * 100 / 255;  // 明度を取得して0-100に正規化
+  return brightness;
+}
+
+// RGB値を取得
+rgb_raw_t Measurer::getRawColor()
+{
+  rgb_raw_t rgb;
+  colorSensor.getRawColor(rgb);
+  return rgb;
+}
+
+// 左モータ角位置取得
+int Measurer::getLeftCount()
+{
+  return leftWheel.getCount();
+}
+
+// 右モータ角位置取得
+int Measurer::getRightCount()
+{
+  return rightWheel.getCount();
+}
+
+// アームモータ角位置取得
+int Measurer::getArmMotorCount()
+{
+  return armMotor.getCount();
+}
+
+// 正面から見て左ボタンの押下状態を取得
+bool Measurer::getLeftButton()
+{
+  return ev3_button_is_pressed(LEFT_BUTTON);
+}
+
+// 正面から見て右ボタンの押下状態を取得
+bool Measurer::getRightButton()
+{
+  return ev3_button_is_pressed(RIGHT_BUTTON);
+}
+
+// 中央ボタンの押下状態を取得
+bool Measurer::getEnterButton()
+{
+  return ev3_button_is_pressed(ENTER_BUTTON);
+}
+
+// 超音波センサからの距離を取得
+int Measurer::getForwardDistance()
+{
+  int distance = sonarSensor.getDistance();
+
+  // センサが認識していない時が-1になる
+  if(distance == -1) distance = 1000;
+
+  return distance;
+}
+
+// SPIKEの電圧を取得
+double Measurer::getVoltage()
+{
+  return (double)ev3_battery_voltage_mV() / 1000.0;
+}

--- a/module/API/Measurer.h
+++ b/module/API/Measurer.h
@@ -1,6 +1,6 @@
 /**
  * @file Measurer.h
- * @brief 計測に用いる関数をまとめたラッパークラス
+ * @brief　計測に用いる関数をまとめたラッパークラス
  * @author keiya121
  */
 
@@ -16,67 +16,67 @@
 class Measurer {
  public:
   /**
-   * コンストラクタ
+   * @brief　コンストラクタ
    */
   Measurer();
 
   /**
-   * 明るさを取得
+   * @brief　明るさを取得
    * @return 反射光の強さ(0-100)
    */
   int getBrightness();
 
   /**
-   * RGB値を取得
+   * @brief　RGB値を取得
    * @return RGB値
    */
   rgb_raw_t getRawColor();
 
   /**
-   * 左モータ角位置取得
+   * @brief　左モータ角位置取得
    * @return 左モータ角位置[deg]
    */
   int getLeftCount();
 
   /**
-   * 右モータ角位置取得
+   * @brief　右モータ角位置取得
    * @return 右モータ角位置[deg]
    */
   int getRightCount();
 
   /**
-   * アームモータ角位置取得
+   * @brief　アームモータ角位置取得
    * @return アームモータ角位置[deg]
    */
   int getArmMotorCount();
 
   /**
-   * 正面から見て左ボタンの押下状態を取得
+   * @brief　正面から見て左ボタンの押下状態を取得
    * @return 左ボタンの押下状態 true:押されてる, false：押されていない
    */
   bool getLeftButton();
 
   /**
-   * 正面から見て右ボタンの押下状態を取得
+   * @brief　正面から見て右ボタンの押下状態を取得
    * @return 右ボタンの押下状態 true:押されてる, false：押されていない
    */
   bool getRightButton();
 
   /**
-   * 中央ボタンの押下状態を取得
+   * @brief　中央ボタンの押下状態を取得
    * @return 中央ボタンの押下状態 true:押されてる, false：押されていない
    */
   bool getEnterButton();
 
   /**
-   * 超音波センサからの距離を取得
+   * @brief　超音波センサからの距離を取得
    * @return 超音波センサからの距離[cm]
    * @note センサが認識していない時は1000を返す
    */
   int getForwardDistance();
 
   /**
-   * SPIKEの電圧を取得
+   * @brief　SPIKEの電圧を取得
    * @return SPIKEの電圧[V]
    */
   double getVoltage();

--- a/module/API/Measurer.h
+++ b/module/API/Measurer.h
@@ -1,0 +1,92 @@
+/**
+ * @file Measurer.h
+ * @brief 計測に用いる関数をまとめたラッパークラス
+ * @author keiya121
+ */
+
+#ifndef MEASURER_H
+#define MEASURER_H
+
+#include <algorithm>
+#include "ev3api.h"
+#include "ColorSensor.h"
+#include "SonarSensor.h"
+#include "Motor.h"
+
+class Measurer {
+ public:
+  /**
+   * コンストラクタ
+   */
+  Measurer();
+
+  /**
+   * 明るさを取得
+   * @return 反射光の強さ(0-100)
+   */
+  int getBrightness();
+
+  /**
+   * RGB値を取得
+   * @return RGB値
+   */
+  rgb_raw_t getRawColor();
+
+  /**
+   * 左モータ角位置取得
+   * @return 左モータ角位置[deg]
+   */
+  int getLeftCount();
+
+  /**
+   * 右モータ角位置取得
+   * @return 右モータ角位置[deg]
+   */
+  int getRightCount();
+
+  /**
+   * アームモータ角位置取得
+   * @return アームモータ角位置[deg]
+   */
+  int getArmMotorCount();
+
+  /**
+   * 正面から見て左ボタンの押下状態を取得
+   * @return 左ボタンの押下状態 true:押されてる, false：押されていない
+   */
+  bool getLeftButton();
+
+  /**
+   * 正面から見て右ボタンの押下状態を取得
+   * @return 右ボタンの押下状態 true:押されてる, false：押されていない
+   */
+  bool getRightButton();
+
+  /**
+   * 中央ボタンの押下状態を取得
+   * @return 中央ボタンの押下状態 true:押されてる, false：押されていない
+   */
+  bool getEnterButton();
+
+  /**
+   * 超音波センサからの距離を取得
+   * @return 超音波センサからの距離[cm]
+   * @note センサが認識していない時は1000を返す
+   */
+  int getForwardDistance();
+
+  /**
+   * SPIKEの電圧を取得
+   * @return SPIKEの電圧[V]
+   */
+  double getVoltage();
+
+ private:
+  ev3api::ColorSensor colorSensor;
+  ev3api::SonarSensor sonarSensor;
+  ev3api::Motor leftWheel;
+  ev3api::Motor rightWheel;
+  ev3api::Motor armMotor;
+};
+
+#endif

--- a/module/EtRobocon2024.cpp
+++ b/module/EtRobocon2024.cpp
@@ -6,10 +6,9 @@
 
 #include "EtRobocon2024.h"
 // ev3api.hをインクルードしているものは.cppに書く
-#include "ev3api.h"
-#include "ColorSensor.h"
-#include "SonarSensor.h"
-#include "Measurer.h"
+// #include "ev3api.h"
+// #include "ColorSensor.h"
+// #include "SonarSensor.h"
 // #include "Motor.h"
 // #include "Clock.h"
 
@@ -28,42 +27,8 @@ void EtRobocon2024::start()
   // ev3api::Motor* _armMotorPtr = new ev3api::Motor(armMotorPort);
   // ev3api::Clock* _clockPtr = new ev3api::Clock();
 
-  const int BUF_SIZE = 128;
-  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
-
-  Measurer measurer;
-
-  rgb_raw_t actualColor = measurer.getRawColor();
-  snprintf(buf, BUF_SIZE, "%s", actualColor);
-
-  int actualBright = measurer.getBrightness();
-  snprintf(buf, BUF_SIZE, "%s", actualBright);
-
-  int actualLeftCount = measurer.getLeftCount();
-  snprintf(buf, BUF_SIZE, "%s", actualLeftCount);
-
-  int actualRightCount = measurer.getRightCount();
-  snprintf(buf, BUF_SIZE, "%s", actualRightCount);
-
-  int actualMotorCount = measurer.getArmMotorCount();
-  snprintf(buf, BUF_SIZE, "%s", actualMotorCount);
-
-  bool actualLeftButton = measurer.getLeftButton();
-  snprintf(buf, BUF_SIZE, "%s", actualLeftButton);
-
-  bool actualRightButton = measurer.getRightButton();
-  snprintf(buf, BUF_SIZE, "%s", actualRightButton);
-
-  bool actualEnterButton = measurer.getEnterButton();
-  snprintf(buf, BUF_SIZE, "%s", actualEnterButton);
-
-  int actualForwardDistance = measurer.getForwardDistance();
-  snprintf(buf, BUF_SIZE, "%s", actualForwardDistance);
-
-  int actualVoltage = measurer.getVoltage();
-  snprintf(buf, BUF_SIZE, "%s", actualVoltage);
-
-  
+  // const int BUF_SIZE = 128;
+  // char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
 
   // bool isLeftCourse = false;
   // bool isLeftEdge = false;

--- a/module/EtRobocon2024.cpp
+++ b/module/EtRobocon2024.cpp
@@ -6,9 +6,10 @@
 
 #include "EtRobocon2024.h"
 // ev3api.hをインクルードしているものは.cppに書く
-// #include "ev3api.h"
-// #include "ColorSensor.h"
-// #include "SonarSensor.h"
+#include "ev3api.h"
+#include "ColorSensor.h"
+#include "SonarSensor.h"
+#include "Measurer.h"
 // #include "Motor.h"
 // #include "Clock.h"
 
@@ -27,8 +28,42 @@ void EtRobocon2024::start()
   // ev3api::Motor* _armMotorPtr = new ev3api::Motor(armMotorPort);
   // ev3api::Clock* _clockPtr = new ev3api::Clock();
 
-  // const int BUF_SIZE = 128;
-  // char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+  const int BUF_SIZE = 128;
+  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+
+  Measurer measurer;
+
+  rgb_raw_t actualColor = measurer.getRawColor();
+  snprintf(buf, BUF_SIZE, "%s", actualColor);
+
+  int actualBright = measurer.getBrightness();
+  snprintf(buf, BUF_SIZE, "%s", actualBright);
+
+  int actualLeftCount = measurer.getLeftCount();
+  snprintf(buf, BUF_SIZE, "%s", actualLeftCount);
+
+  int actualRightCount = measurer.getRightCount();
+  snprintf(buf, BUF_SIZE, "%s", actualRightCount);
+
+  int actualMotorCount = measurer.getArmMotorCount();
+  snprintf(buf, BUF_SIZE, "%s", actualMotorCount);
+
+  bool actualLeftButton = measurer.getLeftButton();
+  snprintf(buf, BUF_SIZE, "%s", actualLeftButton);
+
+  bool actualRightButton = measurer.getRightButton();
+  snprintf(buf, BUF_SIZE, "%s", actualRightButton);
+
+  bool actualEnterButton = measurer.getEnterButton();
+  snprintf(buf, BUF_SIZE, "%s", actualEnterButton);
+
+  int actualForwardDistance = measurer.getForwardDistance();
+  snprintf(buf, BUF_SIZE, "%s", actualForwardDistance);
+
+  int actualVoltage = measurer.getVoltage();
+  snprintf(buf, BUF_SIZE, "%s", actualVoltage);
+
+  
 
   // bool isLeftCourse = false;
   // bool isLeftEdge = false;

--- a/test/DummyRobot.cpp
+++ b/test/DummyRobot.cpp
@@ -4,7 +4,6 @@
  * @author keiya121
  */
 
-
 #include "DummyRobot.h"
 
 // 静的メンバ変数の初期化
@@ -14,11 +13,13 @@ DummyRobot::ButtonState DummyRobot::buttonState = DummyRobot::ButtonState::none;
 DummyRobot::DummyRobot() {}
 
 // 実機内部のボタンの押下状態を設定する静的メソッド
-void DummyRobot::setButtonState(ButtonState state) {
-    buttonState = state;
+void DummyRobot::setButtonState(ButtonState state)
+{
+  buttonState = state;
 }
 
 // 実機内部のボタンの押下状態を取得する静的メソッド
-DummyRobot::ButtonState DummyRobot::getButtonState() {
-    return buttonState;
+DummyRobot::ButtonState DummyRobot::getButtonState()
+{
+  return buttonState;
 }

--- a/test/DummyRobot.cpp
+++ b/test/DummyRobot.cpp
@@ -1,0 +1,24 @@
+/**
+ * @file   DummyRobot.cpp
+ * @brief  実機内部の状態を管理するダミーファイル
+ * @author keiya121
+ */
+
+
+#include "DummyRobot.h"
+
+// 静的メンバ変数の初期化
+DummyRobot::ButtonState DummyRobot::buttonState = DummyRobot::ButtonState::none;
+
+// コンストラクタ
+DummyRobot::DummyRobot() {}
+
+// 実機内部のボタンの押下状態を設定する静的メソッド
+void DummyRobot::setButtonState(ButtonState state) {
+    buttonState = state;
+}
+
+// 実機内部のボタンの押下状態を取得する静的メソッド
+DummyRobot::ButtonState DummyRobot::getButtonState() {
+    return buttonState;
+}

--- a/test/DummyRobot.h
+++ b/test/DummyRobot.h
@@ -1,0 +1,34 @@
+/**
+ * @file   DummyRobot.h
+ * @brief  実機内部の状態を管理するダミーファイル
+ * @author keiya121
+ */
+
+#ifndef DUMMYROBOT_H
+#define DUMMYROBOT_H
+
+class DummyRobot {
+public:
+    // 実機内部のボタンの押下状態を表す列挙型
+    enum class ButtonState {
+        left,     // 実機の正面から見て左側のボタンが押されている状態
+        enter,    // 実機の中央ボタンが押されている状態
+        right,    // 実機の正面から見て右側のボタンが押されている状態
+        none      // ボタンがいずれも押されていない状態
+    };
+
+    // コンストラクタ
+    DummyRobot();
+
+    // 実機内部のボタンの押下状態を設定するメソッド
+    static void setButtonState(ButtonState state);
+
+    // 実機内部のボタンの押下状態を取得するメソッド
+    static ButtonState getButtonState() ;
+
+private:
+    // 実機内部のボタンの押下状態を管理するメンバ変数
+    static ButtonState buttonState;
+};
+
+#endif

--- a/test/DummyRobot.h
+++ b/test/DummyRobot.h
@@ -8,27 +8,27 @@
 #define DUMMYROBOT_H
 
 class DummyRobot {
-public:
-    // 実機内部のボタンの押下状態を表す列挙型
-    enum class ButtonState {
-        left,     // 実機の正面から見て左側のボタンが押されている状態
-        enter,    // 実機の中央ボタンが押されている状態
-        right,    // 実機の正面から見て右側のボタンが押されている状態
-        none      // ボタンがいずれも押されていない状態
-    };
+ public:
+  // 実機内部のボタンの押下状態を表す列挙型
+  enum class ButtonState {
+    left,   // 実機の正面から見て左側のボタンが押されている状態
+    enter,  // 実機の中央ボタンが押されている状態
+    right,  // 実機の正面から見て右側のボタンが押されている状態
+    none    // ボタンがいずれも押されていない状態
+  };
 
-    // コンストラクタ
-    DummyRobot();
+  // コンストラクタ
+  DummyRobot();
 
-    // 実機内部のボタンの押下状態を設定するメソッド
-    static void setButtonState(ButtonState state);
+  // 実機内部のボタンの押下状態を設定するメソッド
+  static void setButtonState(ButtonState state);
 
-    // 実機内部のボタンの押下状態を取得するメソッド
-    static ButtonState getButtonState() ;
+  // 実機内部のボタンの押下状態を取得するメソッド
+  static ButtonState getButtonState();
 
-private:
-    // 実機内部のボタンの押下状態を管理するメンバ変数
-    static ButtonState buttonState;
+ private:
+  // 実機内部のボタンの押下状態を管理するメンバ変数
+  static ButtonState buttonState;
 };
 
 #endif

--- a/test/MeasurerTest.cpp
+++ b/test/MeasurerTest.cpp
@@ -1,10 +1,11 @@
 /**
  * @file MeasurerTest.cpp
  * @brief Measurerクラスをテストする
- * @author Keiya121
+ * @author keiya121
  */
 
 #include "Measurer.h"
+#include "DummyRobot.h"
 #include <gtest/gtest.h>
 
 // rgb_raw_tの比較用関数
@@ -14,34 +15,28 @@ bool eqRgb(rgb_raw_t rgb1, rgb_raw_t rgb2)
 }
 
 namespace etrobocon2024_test {
+
+  //RGB値取得テスト
   TEST(MeasurerTest, getRawColor)
   {
+    Measurer measurer;
     rgb_raw_t expected1 = { 8, 9, 10 };       // black
     rgb_raw_t expected2 = { 104, 101, 146 };  // white
     rgb_raw_t expected3 = { 111, 19, 19 };    // red
     rgb_raw_t expected4 = { 120, 108, 71 };   // yellow
     rgb_raw_t expected5 = { 4, 75, 35 };      // green
     rgb_raw_t expected6 = { 81, 92, 144 };    // blue
-    rgb_raw_t actual = Measurer::getRawColor();
+    rgb_raw_t actual = measurer.getRawColor();
 
     ASSERT_TRUE(eqRgb(actual, expected1) || eqRgb(actual, expected2) || eqRgb(actual, expected3)
                 || eqRgb(actual, expected4) || eqRgb(actual, expected5)
                 || eqRgb(actual, expected6));
   }
 
+  //明度取得テスト
   TEST(MeasurerTest, getBrightness)
   {
-    /**
-    getRawColorの基準となるRGB値
-
-    rgb_raw_t expectedRgb1 = { 8, 9, 10 };       // black
-    rgb_raw_t expectedRgb2 = { 104, 101, 146 };  // white
-    rgb_raw_t expectedRgb3 = { 111, 19, 19 };    // red
-    rgb_raw_t expectedRgb4 = { 120, 108, 71 };   // yellow
-    rgb_raw_t expectedRgb5 = { 4, 75, 35 };      // green
-    rgb_raw_t expectedRgb6 = { 81, 92, 144 };    // blue
-    **/
-
+    Measurer measurer;
     // 各色に対応する明度
     int expected1 = 3;
     int expected2 = 57;
@@ -49,32 +44,126 @@ namespace etrobocon2024_test {
     int expected4 = 47;
     int expected5 = 29;
     int expected6 = 56;
-    int actual = Measurer::getBrightness();
+    int actual = measurer.getBrightness();
     ASSERT_TRUE(actual == expected1 || actual == expected2 || actual == expected3
                 || actual == expected4 || actual == expected5 || actual == expected6);
   }
 
+  //左モーター角位置取得テスト
   TEST(MeasurerTest, getLeftCount)
   {
+    Measurer measurer;
     int expected = 0;
-    int actual = Measurer::getLeftCount();
+    int actual = measurer.getLeftCount();
 
     EXPECT_EQ(expected, actual);
   }
 
+  //右モーター角位置取得テスト
   TEST(MeasurerTest, getRightCount)
   {
+    Measurer measurer;
     int expected = 0;
-    int actual = Measurer::getRightCount();
+    int actual = measurer.getRightCount();
 
     EXPECT_EQ(expected, actual);
   }
 
+  //アームモーター角位置取得テスト
   TEST(MeasurerTest, getArmMotorCount)
   {
+    Measurer measurer;
     int expected = 0;
-    int actual = Measurer::getArmMotorCount();
+    int actual = measurer.getArmMotorCount();
 
     EXPECT_EQ(expected, actual);
   }
+
+  //実機側で左側のボタンが押された状態で、左側のボタンを押した際の処理を行うケースのテスト
+  TEST(LeftButtonTestTrue, getLeftButton)
+  {
+    Measurer measurer;
+    DummyRobot::setButtonState(DummyRobot::ButtonState::left); //実機のボタン押下状態を「左」に設定
+    bool expected = true;
+    bool actual = measurer.getLeftButton();
+
+    EXPECT_EQ(expected, actual);
+  }
+
+  //実機側で左側以外のボタンが押された状態で、左側のボタンを押した際の処理を行うケースのテスト
+  TEST(LeftButtonTestFalse, getLeftButton)
+  {
+    Measurer measurer;
+    DummyRobot::setButtonState(DummyRobot::ButtonState::right); //実機のボタン押下状態を「右」に設定
+    bool expected = false;
+    bool actual = measurer.getLeftButton();
+
+    EXPECT_EQ(expected, actual);
+  }
+
+  //実機側で右側のボタンが押された状態で、右側のボタンを押した際の処理を行うケースのテスト
+  TEST(RightButtonTestTrue, getRightButton)
+  {
+    Measurer measurer;
+    DummyRobot::setButtonState(DummyRobot::ButtonState::right); //実機のボタン押下状態を「右」に設定
+    bool expected = true;
+    bool actual = measurer.getRightButton();
+
+    EXPECT_EQ(expected, actual);
+  }
+
+  //実機側で右側以外のボタンが押された状態で、右側のボタンを押した際の処理を行うケースのテスト
+  TEST(RightButtonTestFalse, getRightButton)
+  {
+    Measurer measurer;
+    DummyRobot::setButtonState(DummyRobot::ButtonState::enter); //実機のボタン押下状態を「中央」に設定
+    bool expected = false;
+    bool actual = measurer.getRightButton();
+
+    EXPECT_EQ(expected, actual);
+  }
+
+  //実機側で中央のボタンが押された状態で、中央のボタンを押した際の処理を行うケースのテスト
+  TEST(EnterButtonTestTrue, getEnterButton)
+  {
+    Measurer measurer;
+    DummyRobot::setButtonState(DummyRobot::ButtonState::enter); //実機のボタン押下状態を「中央」に設定
+    bool expected = true;
+    bool actual = measurer.getEnterButton();
+
+    EXPECT_EQ(expected, actual);
+  }
+
+  //実機側で中央以外のボタンが押された状態で、中央のボタンを押した際の処理を行うケースのテスト
+  TEST(EnterButtonTestFalse, getEnterButton)
+  {
+    Measurer measurer;
+    DummyRobot::setButtonState(DummyRobot::ButtonState::right); //実機のボタン押下状態を「右」に設定
+    bool expected = false;
+    bool actual = measurer.getEnterButton();
+
+    EXPECT_EQ(expected, actual);
+  }
+
+  //超音波センサからの距離取得テスト
+  TEST(MeasurerTest, getForwardDistance)
+  {
+    Measurer measurer;
+    int expected = 99; //参照: SonarSensor.cpp　
+    int actual = measurer.getForwardDistance();
+
+    EXPECT_EQ(expected, actual);
+  }
+
+  //SPIKEの電圧取得テスト
+  TEST(MeasurerTest, getVoltage)
+  {
+    Measurer measurer;
+    int expected = 7;
+    int actual = measurer.getVoltage();
+
+    EXPECT_EQ(expected, actual);
+  }
+
+
 }  // namespace etrobocon2024_test

--- a/test/MeasurerTest.cpp
+++ b/test/MeasurerTest.cpp
@@ -17,7 +17,7 @@ bool eqRgb(rgb_raw_t rgb1, rgb_raw_t rgb2)
 namespace etrobocon2024_test {
 
   //RGB値取得テスト
-  TEST(MeasurerTest, getRawColor)
+  TEST(RawColorTest, getRawColor)
   {
     Measurer measurer;
     rgb_raw_t expected1 = { 8, 9, 10 };       // black
@@ -34,7 +34,7 @@ namespace etrobocon2024_test {
   }
 
   //明度取得テスト
-  TEST(MeasurerTest, getBrightness)
+  TEST(BrightnessTest, getBrightness)
   {
     Measurer measurer;
     // 各色に対応する明度
@@ -50,7 +50,7 @@ namespace etrobocon2024_test {
   }
 
   //左モーター角位置取得テスト
-  TEST(MeasurerTest, getLeftCount)
+  TEST(leftCountTest, getLeftCount)
   {
     Measurer measurer;
     int expected = 0;
@@ -60,7 +60,7 @@ namespace etrobocon2024_test {
   }
 
   //右モーター角位置取得テスト
-  TEST(MeasurerTest, getRightCount)
+  TEST(rightCountTest, getRightCount)
   {
     Measurer measurer;
     int expected = 0;
@@ -70,7 +70,7 @@ namespace etrobocon2024_test {
   }
 
   //アームモーター角位置取得テスト
-  TEST(MeasurerTest, getArmMotorCount)
+  TEST(measurerTest, getArmMotorCount)
   {
     Measurer measurer;
     int expected = 0;
@@ -79,8 +79,8 @@ namespace etrobocon2024_test {
     EXPECT_EQ(expected, actual);
   }
 
-  //実機側で左側のボタンが押された状態で、左側のボタンを押した際の処理を行うケースのテスト
-  TEST(LeftButtonTestTrue, getLeftButton)
+  //左側ボタン押下時、実機内部で左側ボタン押下時の処理を行うケースのテスト
+  TEST(leftButtonTestTrue, getLeftButton)
   {
     Measurer measurer;
     DummyRobot::setButtonState(DummyRobot::ButtonState::left); //実機のボタン押下状態を「左」に設定
@@ -90,8 +90,8 @@ namespace etrobocon2024_test {
     EXPECT_EQ(expected, actual);
   }
 
-  //実機側で左側以外のボタンが押された状態で、左側のボタンを押した際の処理を行うケースのテスト
-  TEST(LeftButtonTestFalse, getLeftButton)
+  //左側以外のボタン押下時（本テストでは右側)、実機内部で左側ボタン押下時の処理を行うケースのテスト
+  TEST(leftButtonTestFalse, getLeftButton)
   {
     Measurer measurer;
     DummyRobot::setButtonState(DummyRobot::ButtonState::right); //実機のボタン押下状態を「右」に設定
@@ -101,8 +101,8 @@ namespace etrobocon2024_test {
     EXPECT_EQ(expected, actual);
   }
 
-  //実機側で右側のボタンが押された状態で、右側のボタンを押した際の処理を行うケースのテスト
-  TEST(RightButtonTestTrue, getRightButton)
+  //右側ボタン押下時、実機内部で右側ボタン押下時の処理を行うケースのテスト
+  TEST(rightButtonTestTrue, getRightButton)
   {
     Measurer measurer;
     DummyRobot::setButtonState(DummyRobot::ButtonState::right); //実機のボタン押下状態を「右」に設定
@@ -112,8 +112,8 @@ namespace etrobocon2024_test {
     EXPECT_EQ(expected, actual);
   }
 
-  //実機側で右側以外のボタンが押された状態で、右側のボタンを押した際の処理を行うケースのテスト
-  TEST(RightButtonTestFalse, getRightButton)
+  //右側以外のボタン押下時（本テストでは中央)、実機内部で右側ボタン押下時の処理を行うケースのテスト
+  TEST(rightButtonTestFalse, getRightButton)
   {
     Measurer measurer;
     DummyRobot::setButtonState(DummyRobot::ButtonState::enter); //実機のボタン押下状態を「中央」に設定
@@ -123,8 +123,8 @@ namespace etrobocon2024_test {
     EXPECT_EQ(expected, actual);
   }
 
-  //実機側で中央のボタンが押された状態で、中央のボタンを押した際の処理を行うケースのテスト
-  TEST(EnterButtonTestTrue, getEnterButton)
+  //中央ボタン押下時、実機内部で中央ボタン押下時の処理を行うケースのテスト
+  TEST(enterButtonTestTrue, getEnterButton)
   {
     Measurer measurer;
     DummyRobot::setButtonState(DummyRobot::ButtonState::enter); //実機のボタン押下状態を「中央」に設定
@@ -134,8 +134,8 @@ namespace etrobocon2024_test {
     EXPECT_EQ(expected, actual);
   }
 
-  //実機側で中央以外のボタンが押された状態で、中央のボタンを押した際の処理を行うケースのテスト
-  TEST(EnterButtonTestFalse, getEnterButton)
+  //中央以外のボタン押下時（本テストでは右)、実機内部で中央ボタン押下時の処理を行うケースのテスト
+  TEST(enterButtonTestFalse, getEnterButton)
   {
     Measurer measurer;
     DummyRobot::setButtonState(DummyRobot::ButtonState::right); //実機のボタン押下状態を「右」に設定
@@ -146,7 +146,7 @@ namespace etrobocon2024_test {
   }
 
   //超音波センサからの距離取得テスト
-  TEST(MeasurerTest, getForwardDistance)
+  TEST(forwardDistanceTest, getForwardDistance)
   {
     Measurer measurer;
     int expected = 99; //参照: SonarSensor.cpp　
@@ -155,15 +155,18 @@ namespace etrobocon2024_test {
     EXPECT_EQ(expected, actual);
   }
 
-  //SPIKEの電圧取得テスト
-  TEST(MeasurerTest, getVoltage)
-  {
+// SPIKEの電圧取得テスト
+TEST(voltageTest, getVoltage)
+{
     Measurer measurer;
-    int expected = 7;
+    int expected_min = 4;
+    int expected_max = 7;
     int actual = measurer.getVoltage();
 
-    EXPECT_EQ(expected, actual);
-  }
+    EXPECT_GE(actual, expected_min);  // 4以上であることを確認
+    EXPECT_LE(actual, expected_max);  // 7以下であることを確認
+}
+
 
 
 }  // namespace etrobocon2024_test

--- a/test/MeasurerTest.cpp
+++ b/test/MeasurerTest.cpp
@@ -1,0 +1,80 @@
+/**
+ * @file MeasurerTest.cpp
+ * @brief Measurerクラスをテストする
+ * @author Keiya121
+ */
+
+#include "Measurer.h"
+#include <gtest/gtest.h>
+
+// rgb_raw_tの比較用関数
+bool eqRgb(rgb_raw_t rgb1, rgb_raw_t rgb2)
+{
+  return rgb1.r == rgb2.r && rgb1.g == rgb2.g && rgb1.b == rgb2.b;
+}
+
+namespace etrobocon2024_test {
+  TEST(MeasurerTest, getRawColor)
+  {
+    rgb_raw_t expected1 = { 8, 9, 10 };       // black
+    rgb_raw_t expected2 = { 104, 101, 146 };  // white
+    rgb_raw_t expected3 = { 111, 19, 19 };    // red
+    rgb_raw_t expected4 = { 120, 108, 71 };   // yellow
+    rgb_raw_t expected5 = { 4, 75, 35 };      // green
+    rgb_raw_t expected6 = { 81, 92, 144 };    // blue
+    rgb_raw_t actual = Measurer::getRawColor();
+
+    ASSERT_TRUE(eqRgb(actual, expected1) || eqRgb(actual, expected2) || eqRgb(actual, expected3)
+                || eqRgb(actual, expected4) || eqRgb(actual, expected5)
+                || eqRgb(actual, expected6));
+  }
+
+  TEST(MeasurerTest, getBrightness)
+  {
+    /**
+    getRawColorの基準となるRGB値
+
+    rgb_raw_t expectedRgb1 = { 8, 9, 10 };       // black
+    rgb_raw_t expectedRgb2 = { 104, 101, 146 };  // white
+    rgb_raw_t expectedRgb3 = { 111, 19, 19 };    // red
+    rgb_raw_t expectedRgb4 = { 120, 108, 71 };   // yellow
+    rgb_raw_t expectedRgb5 = { 4, 75, 35 };      // green
+    rgb_raw_t expectedRgb6 = { 81, 92, 144 };    // blue
+    **/
+
+    // 各色に対応する明度
+    int expected1 = 3;
+    int expected2 = 57;
+    int expected3 = 43;
+    int expected4 = 47;
+    int expected5 = 29;
+    int expected6 = 56;
+    int actual = Measurer::getBrightness();
+    ASSERT_TRUE(actual == expected1 || actual == expected2 || actual == expected3
+                || actual == expected4 || actual == expected5 || actual == expected6);
+  }
+
+  TEST(MeasurerTest, getLeftCount)
+  {
+    int expected = 0;
+    int actual = Measurer::getLeftCount();
+
+    EXPECT_EQ(expected, actual);
+  }
+
+  TEST(MeasurerTest, getRightCount)
+  {
+    int expected = 0;
+    int actual = Measurer::getRightCount();
+
+    EXPECT_EQ(expected, actual);
+  }
+
+  TEST(MeasurerTest, getArmMotorCount)
+  {
+    int expected = 0;
+    int actual = Measurer::getArmMotorCount();
+
+    EXPECT_EQ(expected, actual);
+  }
+}  // namespace etrobocon2024_test

--- a/test/MeasurerTest.cpp
+++ b/test/MeasurerTest.cpp
@@ -16,7 +16,7 @@ bool eqRgb(rgb_raw_t rgb1, rgb_raw_t rgb2)
 
 namespace etrobocon2024_test {
 
-  //RGB値取得テスト
+  // RGB値取得テスト
   TEST(RawColorTest, getRawColor)
   {
     Measurer measurer;
@@ -33,7 +33,7 @@ namespace etrobocon2024_test {
                 || eqRgb(actual, expected6));
   }
 
-  //明度取得テスト
+  // 明度取得テスト
   TEST(BrightnessTest, getBrightness)
   {
     Measurer measurer;
@@ -49,7 +49,7 @@ namespace etrobocon2024_test {
                 || actual == expected4 || actual == expected5 || actual == expected6);
   }
 
-  //左モーター角位置取得テスト
+  // 左モーター角位置取得テスト
   TEST(leftCountTest, getLeftCount)
   {
     Measurer measurer;
@@ -59,7 +59,7 @@ namespace etrobocon2024_test {
     EXPECT_EQ(expected, actual);
   }
 
-  //右モーター角位置取得テスト
+  // 右モーター角位置取得テスト
   TEST(rightCountTest, getRightCount)
   {
     Measurer measurer;
@@ -69,7 +69,7 @@ namespace etrobocon2024_test {
     EXPECT_EQ(expected, actual);
   }
 
-  //アームモーター角位置取得テスト
+  // アームモーター角位置取得テスト
   TEST(measurerTest, getArmMotorCount)
   {
     Measurer measurer;
@@ -79,85 +79,91 @@ namespace etrobocon2024_test {
     EXPECT_EQ(expected, actual);
   }
 
-  //左側ボタン押下時、実機内部で左側ボタン押下時の処理を行うケースのテスト
+  // 左側ボタン押下時、実機内部で左側ボタン押下時の処理を行うケースのテスト
   TEST(leftButtonTestTrue, getLeftButton)
   {
     Measurer measurer;
-    DummyRobot::setButtonState(DummyRobot::ButtonState::left); //実機のボタン押下状態を「左」に設定
+    DummyRobot::setButtonState(
+        DummyRobot::ButtonState::left);  // 実機のボタン押下状態を「左」に設定
     bool expected = true;
     bool actual = measurer.getLeftButton();
 
     EXPECT_EQ(expected, actual);
   }
 
-  //左側以外のボタン押下時（本テストでは右側)、実機内部で左側ボタン押下時の処理を行うケースのテスト
+  // 左側以外のボタン押下時（本テストでは右側)、実機内部で左側ボタン押下時の処理を行うケースのテスト
   TEST(leftButtonTestFalse, getLeftButton)
   {
     Measurer measurer;
-    DummyRobot::setButtonState(DummyRobot::ButtonState::right); //実機のボタン押下状態を「右」に設定
+    DummyRobot::setButtonState(
+        DummyRobot::ButtonState::right);  // 実機のボタン押下状態を「右」に設定
     bool expected = false;
     bool actual = measurer.getLeftButton();
 
     EXPECT_EQ(expected, actual);
   }
 
-  //右側ボタン押下時、実機内部で右側ボタン押下時の処理を行うケースのテスト
+  // 右側ボタン押下時、実機内部で右側ボタン押下時の処理を行うケースのテスト
   TEST(rightButtonTestTrue, getRightButton)
   {
     Measurer measurer;
-    DummyRobot::setButtonState(DummyRobot::ButtonState::right); //実機のボタン押下状態を「右」に設定
+    DummyRobot::setButtonState(
+        DummyRobot::ButtonState::right);  // 実機のボタン押下状態を「右」に設定
     bool expected = true;
     bool actual = measurer.getRightButton();
 
     EXPECT_EQ(expected, actual);
   }
 
-  //右側以外のボタン押下時（本テストでは中央)、実機内部で右側ボタン押下時の処理を行うケースのテスト
+  // 右側以外のボタン押下時（本テストでは中央)、実機内部で右側ボタン押下時の処理を行うケースのテスト
   TEST(rightButtonTestFalse, getRightButton)
   {
     Measurer measurer;
-    DummyRobot::setButtonState(DummyRobot::ButtonState::enter); //実機のボタン押下状態を「中央」に設定
+    DummyRobot::setButtonState(
+        DummyRobot::ButtonState::enter);  // 実機のボタン押下状態を「中央」に設定
     bool expected = false;
     bool actual = measurer.getRightButton();
 
     EXPECT_EQ(expected, actual);
   }
 
-  //中央ボタン押下時、実機内部で中央ボタン押下時の処理を行うケースのテスト
+  // 中央ボタン押下時、実機内部で中央ボタン押下時の処理を行うケースのテスト
   TEST(enterButtonTestTrue, getEnterButton)
   {
     Measurer measurer;
-    DummyRobot::setButtonState(DummyRobot::ButtonState::enter); //実機のボタン押下状態を「中央」に設定
+    DummyRobot::setButtonState(
+        DummyRobot::ButtonState::enter);  // 実機のボタン押下状態を「中央」に設定
     bool expected = true;
     bool actual = measurer.getEnterButton();
 
     EXPECT_EQ(expected, actual);
   }
 
-  //中央以外のボタン押下時（本テストでは右)、実機内部で中央ボタン押下時の処理を行うケースのテスト
+  // 中央以外のボタン押下時（本テストでは右)、実機内部で中央ボタン押下時の処理を行うケースのテスト
   TEST(enterButtonTestFalse, getEnterButton)
   {
     Measurer measurer;
-    DummyRobot::setButtonState(DummyRobot::ButtonState::right); //実機のボタン押下状態を「右」に設定
+    DummyRobot::setButtonState(
+        DummyRobot::ButtonState::right);  // 実機のボタン押下状態を「右」に設定
     bool expected = false;
     bool actual = measurer.getEnterButton();
 
     EXPECT_EQ(expected, actual);
   }
 
-  //超音波センサからの距離取得テスト
+  // 超音波センサからの距離取得テスト
   TEST(forwardDistanceTest, getForwardDistance)
   {
     Measurer measurer;
-    int expected = 99; //参照: SonarSensor.cpp　
+    int expected = 99;  // 参照: SonarSensor.cpp　
     int actual = measurer.getForwardDistance();
 
     EXPECT_EQ(expected, actual);
   }
 
-// SPIKEの電圧取得テスト
-TEST(voltageTest, getVoltage)
-{
+  // SPIKEの電圧取得テスト
+  TEST(voltageTest, getVoltage)
+  {
     Measurer measurer;
     int expected_min = 4;
     int expected_max = 7;
@@ -165,8 +171,6 @@ TEST(voltageTest, getVoltage)
 
     EXPECT_GE(actual, expected_min);  // 4以上であることを確認
     EXPECT_LE(actual, expected_max);  // 7以下であることを確認
-}
-
-
+  }
 
 }  // namespace etrobocon2024_test

--- a/test/dummy/ColorSensor.cpp
+++ b/test/dummy/ColorSensor.cpp
@@ -1,0 +1,37 @@
+/**
+ * @file ColorSensor.cpp
+ * @brief カラーセンサクラスで用いる関数（ダミー）
+ * @author keiya121
+ */
+
+#include "ColorSensor.h"
+using namespace ev3api;
+
+// コンストラクタ
+ColorSensor::ColorSensor(ePortS port) {}
+
+// RGB値を取得
+void ColorSensor::getRawColor(rgb_raw_t& rgb)
+{
+  int index = rand() % 6;
+  switch(index) {
+    case 0:
+      rgb = { 8, 9, 10 };  // black
+      break;
+    case 1:
+      rgb = { 104, 101, 146 };  // white
+      break;
+    case 2:
+      rgb = { 111, 19, 19 };  // red
+      break;
+    case 3:
+      rgb = { 120, 108, 71 };  // yellow
+      break;
+    case 4:
+      rgb = { 4, 75, 35 };  // green
+      break;
+    case 5:
+      rgb = { 81, 92, 144 };  // blue
+      break;
+  }
+}

--- a/test/dummy/ColorSensor.h
+++ b/test/dummy/ColorSensor.h
@@ -1,0 +1,38 @@
+/**
+ * @file ColorSensor.h
+ * @brief カラーセンサクラス（ダミー）
+ * @author keiya121
+ */
+
+#ifndef COLOR_SENSOR_H
+#define COLOR_SENSOR_H
+
+#include "Port.h"
+#include <stdlib.h>
+
+typedef struct {
+  int r, g, b;
+} rgb_raw_t;
+
+namespace ev3api {
+
+  // カラーセンサクラス
+  class ColorSensor {
+   public:
+    /**
+     * コンストラクタ
+     * @param port カラーセンサポート番号
+     * @return -
+     */
+    explicit ColorSensor(ePortS port);
+
+    /**
+     * RGB値を取得
+     * @param rgb RGB値を代入する変数（参照渡し）
+     * @return RGBを保持するクラス
+     */
+    void getRawColor(rgb_raw_t& rgb);
+  };
+}  // namespace ev3api
+
+#endif

--- a/test/dummy/Motor.cpp
+++ b/test/dummy/Motor.cpp
@@ -1,0 +1,47 @@
+/**
+ * @file Motor.cpp
+ * @brief モータクラスで用いる関数（ダミー）
+ * @author keiya121
+ */
+
+#include "Motor.h"
+using namespace ev3api;
+
+// コンストラクタ
+Motor::Motor(ePortM _port, bool brake, motor_type_t type) : port(_port) {}
+
+// PORT_B　右モータ
+// PORT_C　左モータ
+// モータ角位置取得
+int Motor::getCount()
+{
+  if(port == PORT_C) {
+    return static_cast<int>(leftCount);
+  } else if(port == PORT_B) {
+    return static_cast<int>(rightCount);
+  } else {
+    return static_cast<int>(armCount);
+  }
+}
+
+// pwm値設定
+void Motor::setPWM(int pwm)
+{
+  if(port == PORT_C) {
+    leftCount += pwm * 0.05;
+  } else if(port == PORT_B) {
+    rightCount += pwm * 0.05;
+  } else {
+    armCount += pwm * 0.05;
+  }
+}
+
+void Motor::reset()
+{
+  leftCount = 0;
+  rightCount = 0;
+}
+
+double Motor::leftCount = 0.0;
+double Motor::rightCount = 0.0;
+double Motor::armCount = 0.0;

--- a/test/dummy/Motor.h
+++ b/test/dummy/Motor.h
@@ -39,7 +39,7 @@ namespace ev3api {
     /**
      * 停止する
      */
-    void stop(){};
+    void stop() {};
 
     void reset();
 

--- a/test/dummy/Motor.h
+++ b/test/dummy/Motor.h
@@ -1,0 +1,54 @@
+/**
+ * @file Motor.h
+ * @brief モータクラス（ダミー）
+ * @author keiya121
+ */
+
+#ifndef MOTOR_H
+#define MOTOR_H
+
+#include "Port.h"
+#include "ev3api.h"
+
+namespace ev3api {
+
+  // モータクラス
+  class Motor {
+   public:
+    /**
+     * コンストラクタ
+     * @param port  モータポート番号
+     * @param brake true:ブレーキモード/false:フロートモード
+     * @param type  モータタイプ
+     * @return -
+     */
+    explicit Motor(ePortM port, bool brake = true, motor_type_t type = LARGE_MOTOR);
+
+    /**
+     * モータ角位置取得
+     * @return モータ角位置[deg]
+     */
+    int getCount();
+
+    /**
+     * pwm値設定
+     * @param pwm pwm値
+     */
+    void setPWM(int pwm);
+
+    /**
+     * 停止する
+     */
+    void stop(){};
+
+    void reset();
+
+   private:
+    static double leftCount;
+    static double rightCount;
+    static double armCount;
+    ePortM port;
+  };
+}  // namespace ev3api
+
+#endif

--- a/test/dummy/Port.h
+++ b/test/dummy/Port.h
@@ -1,0 +1,44 @@
+/**
+ * @file Port.h
+ * @brief ポート関連の列挙体等（ダミー）
+ * @author keiya121
+ */
+#ifndef PORT_H
+#define PORT_H
+
+/**
+ * センサポート番号
+ */
+enum ePortS {
+  PORT_1 = 0, /**< EV3 センサポート1 */
+  PORT_2,     /**< EV3 センサポート2 */
+  PORT_3,     /**< EV3 センサポート3 */
+  PORT_4      /**< EV3 センサポート4 */
+};
+
+/**
+ * モータポート番号
+ */
+enum ePortM {
+  PORT_A = 0, /**< EV3 モータポートA */
+  PORT_B,     /**< EV3 モータポートB */
+  PORT_C,     /**< EV3 モータポートC */
+  PORT_D      /**< EV3 モータポートD */
+};
+
+/**
+ * センサポートに対する電源供給状態
+ */
+enum ePower {
+  POWER_OFF = 0,         /**< 電源供給なし */
+  POWER_LOWSPEED_9V = 1, /**< 9V電源供給 */
+  POWER_LOWSPEED = 2     /**< I2Cデバイス */
+};
+
+/** センサポート数 */
+#define NUM_PORT_S (4)  // number of sensor ports
+
+/** モータポート数 */
+#define NUM_PORT_M (4)  // number of motor ports
+
+#endif

--- a/test/dummy/SonarSensor.cpp
+++ b/test/dummy/SonarSensor.cpp
@@ -1,0 +1,24 @@
+/**
+ * @file SonarSensor.cpp
+ * @brief ソナーセンサクラスで用いる関数（ダミー）
+ * @author keiya121
+ */
+
+#include "SonarSensor.h"
+using namespace ev3api;
+
+// コンストラクタ
+SonarSensor::SonarSensor(ePortS port) : distance(100) {}
+
+// センサーまでの距離を取得
+int SonarSensor::getDistance()
+{
+  // 呼び出すたびにdistanceを1引く（0~100）
+  if(distance == 0) {
+    distance = 100;
+  } else {
+    distance--;
+  }
+
+  return distance;
+}

--- a/test/dummy/SonarSensor.h
+++ b/test/dummy/SonarSensor.h
@@ -1,0 +1,34 @@
+/**
+ * @file SonarSensor.h
+ * @brief ソナーセンサクラスで用いる関数（ダミー）
+ * @author keiya121
+ */
+
+#ifndef SONAR_SENSOR_H
+#define SONAR_SENSOR_H
+
+#include "Port.h"
+
+namespace ev3api {
+
+  // ソナーセンサクラス
+  class SonarSensor {
+   public:
+    /**
+     * コンストラクタ
+     * @param port ソナーセンサポート番号
+     * @return -
+     */
+    explicit SonarSensor(ePortS port);
+
+    /**
+     * 距離を測定する
+     */
+    int getDistance();
+
+   private:
+    int distance;
+  };
+}  // namespace ev3api
+
+#endif

--- a/test/dummy/ev3api_button.cpp
+++ b/test/dummy/ev3api_button.cpp
@@ -10,9 +10,8 @@
 
 bool ev3_button_is_pressed(button_t button)
 {
-
   DummyRobot::ButtonState currentButtonState = DummyRobot::getButtonState();
-  
+
   //   std::cout << "Current ButtonState: ";
   //   switch (currentButtonState) {
   //       case DummyRobot::ButtonState::left:

--- a/test/dummy/ev3api_button.cpp
+++ b/test/dummy/ev3api_button.cpp
@@ -6,35 +6,18 @@
 
 #include "ev3api_button.h"
 #include "../DummyRobot.h"
-#include <iostream>
 
 bool ev3_button_is_pressed(button_t button)
 {
   DummyRobot::ButtonState currentButtonState = DummyRobot::getButtonState();
 
-  //   std::cout << "Current ButtonState: ";
-  //   switch (currentButtonState) {
-  //       case DummyRobot::ButtonState::left:
-  //           std::cout << "Left" << std::endl;
-  //           break;
-  //       case DummyRobot::ButtonState::enter:
-  //           std::cout << "Enter" << std::endl;
-  //           break;
-  //       case DummyRobot::ButtonState::right:
-  //           std::cout << "Right" << std::endl;
-  //           break;
-  //       case DummyRobot::ButtonState::none:
-  //           std::cout << "None" << std::endl;
-  //           break;
-  //   }
-
-  // 左ボタンが押された時（num=0）
+  // 左ボタンが押された時
   if(button == LEFT_BUTTON && currentButtonState == DummyRobot::ButtonState::left) return true;
 
-  // 右ボタンが押された時（num=1）
+  // 右ボタンが押された時
   if(button == RIGHT_BUTTON && currentButtonState == DummyRobot::ButtonState::right) return true;
 
-  // 中央ボタンが押された時（num=2）
+  // 中央ボタンが押された時
   if(button == ENTER_BUTTON && currentButtonState == DummyRobot::ButtonState::enter) return true;
 
   if(button != LEFT_BUTTON && button != RIGHT_BUTTON && button != ENTER_BUTTON) {

--- a/test/dummy/ev3api_button.cpp
+++ b/test/dummy/ev3api_button.cpp
@@ -1,24 +1,42 @@
 /**
  * @file ev3api_button.cpp
  * @brief ボタン関連のダミー
- * @author KakinokiKanta
+ * @author keiya121
  */
 
 #include "ev3api_button.h"
+#include "../DummyRobot.h"
+#include <iostream>
 
 bool ev3_button_is_pressed(button_t button)
 {
-  // 左ボタン，右ボタン，中央ボタンがランダムに押される想定
-  int num = rand() % 3;
+
+  DummyRobot::ButtonState currentButtonState = DummyRobot::getButtonState();
+  
+  //   std::cout << "Current ButtonState: ";
+  //   switch (currentButtonState) {
+  //       case DummyRobot::ButtonState::left:
+  //           std::cout << "Left" << std::endl;
+  //           break;
+  //       case DummyRobot::ButtonState::enter:
+  //           std::cout << "Enter" << std::endl;
+  //           break;
+  //       case DummyRobot::ButtonState::right:
+  //           std::cout << "Right" << std::endl;
+  //           break;
+  //       case DummyRobot::ButtonState::none:
+  //           std::cout << "None" << std::endl;
+  //           break;
+  //   }
 
   // 左ボタンが押された時（num=0）
-  if(button == LEFT_BUTTON && num == 0) return true;
+  if(button == LEFT_BUTTON && currentButtonState == DummyRobot::ButtonState::left) return true;
 
   // 右ボタンが押された時（num=1）
-  if(button == RIGHT_BUTTON && num == 1) return true;
+  if(button == RIGHT_BUTTON && currentButtonState == DummyRobot::ButtonState::right) return true;
 
   // 中央ボタンが押された時（num=2）
-  if(button == ENTER_BUTTON && num == 2) return true;
+  if(button == ENTER_BUTTON && currentButtonState == DummyRobot::ButtonState::enter) return true;
 
   if(button != LEFT_BUTTON && button != RIGHT_BUTTON && button != ENTER_BUTTON) {
     printf("\x1b[31m");  // 前景色を赤に

--- a/test/dummy/ev3api_motor.h
+++ b/test/dummy/ev3api_motor.h
@@ -9,20 +9,20 @@
  * @brief モータポートを表す番号
  */
 typedef enum {
-  EV3_PORT_A = 0,      //ポートA
-  EV3_PORT_B = 1,      //ポートB
-  EV3_PORT_C = 2,      //ポートC
-  EV3_PORT_D = 3,      //ポートD
-  TNUM_MOTOR_PORT = 4  //モータポートの数
+  EV3_PORT_A = 0,      // ポートA
+  EV3_PORT_B = 1,      // ポートB
+  EV3_PORT_C = 2,      // ポートC
+  EV3_PORT_D = 3,      // ポートD
+  TNUM_MOTOR_PORT = 4  // モータポートの数
 } motor_port_t;
 
 /**
  * @brief サポートするモータタイプ
  */
 typedef enum {
-  NONE_MOTOR = 0,     //モータ未接続
-  MEDIUM_MOTOR,       //サーボモータM
-  LARGE_MOTOR,        //サーボモータL
-  UNREGULATED_MOTOR,  //未調整モータ
-  TNUM_MOTOR_TYPE     //モータタイプの数
+  NONE_MOTOR = 0,     // モータ未接続
+  MEDIUM_MOTOR,       // サーボモータM
+  LARGE_MOTOR,        // サーボモータL
+  UNREGULATED_MOTOR,  // 未調整モータ
+  TNUM_MOTOR_TYPE     // モータタイプの数
 } motor_type_t;


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
format-check.yaml の記法を変更。
.clang-formatファイルも合わせて空白を半角スペースに統一。
他は ticket-KLI-29と同様の変更。

## 添付資料
詳細な理由については調査したのですが、わかりませんでした。
調べたところだと、今回変更したような記法が複数のサイトから見つかっています。
https://www.turtlestoffel.com/Clang-Format , 
https://github.com/vllm-project/vllm/blob/main/.github/workflows/clang-format.yml ,
https://community.cesium.com/t/ci-cd-deployment-issues/28272 