### PR TITLE
close #KLI-61 回頭の親クラス、子クラスの作成(角度指定)

### DIFF
--- a/module/Motion/PwmRotation.cpp
+++ b/module/Motion/PwmRotation.cpp
@@ -9,7 +9,7 @@
 using namespace std;
 
 PwmRotation::PwmRotation(int _targetAngle, int _pwm, bool _isClockwise)
-  : Rotation(_pwm, _isClockwise), targetAngle(_targetAngle)
+  : Rotation(_targetAngle, _pwm, _isClockwise)
 {
 }
 
@@ -35,16 +35,9 @@ bool PwmRotation::isMetPrecondition()
   return true;
 }
 
-bool PwmRotation::isMetPostcondition(double initLeftMileage, double initRightMileage, int leftSign,
-                                     int rightSign)
+bool PwmRotation::isMetPostcondition(double targetLeftDistance, double targetRightDistance,
+                                     int leftSign, int rightSign)
 {
-  // 指定した角度に対する目標の走行距離(弧の長さ)
-  double targetDistance = M_PI * TREAD * targetAngle / 360;
-
-  // 目標距離（呼び出し時の走行距離 ± 指定された回転量に必要な距離）
-  double targetLeftDistance = initLeftMileage + targetDistance * leftSign;
-  double targetRightDistance = initRightMileage + targetDistance * rightSign;
-
   // 残りの移動距離を算出
   double diffLeftDistance
       = (targetLeftDistance - Mileage::calculateWheelMileage(measurer.getLeftCount())) * leftSign;

--- a/module/Motion/PwmRotation.cpp
+++ b/module/Motion/PwmRotation.cpp
@@ -13,7 +13,7 @@ PwmRotation::PwmRotation(int _targetAngle, int _pwm, bool _isClockwise)
 {
 }
 
-bool PwmRotation::isMetPrecondition()
+bool PwmRotation::isMetPreCondition()
 {
   const int BUF_SIZE = 256;
   char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
@@ -35,7 +35,7 @@ bool PwmRotation::isMetPrecondition()
   return true;
 }
 
-bool PwmRotation::isMetPostcondition(double targetLeftDistance, double targetRightDistance,
+bool PwmRotation::isMetContCondition(double targetLeftDistance, double targetRightDistance,
                                      int leftSign, int rightSign)
 {
   // 残りの移動距離を算出

--- a/module/Motion/PwmRotation.cpp
+++ b/module/Motion/PwmRotation.cpp
@@ -1,0 +1,71 @@
+/**
+ * @file   PwmRotation.cpp
+ * @brief  Pwm指定回頭動作
+ * @author takahashitom
+ */
+
+#include "PwmRotation.h"
+
+using namespace std;
+
+PwmRotation::PwmRotation(int _targetAngle, int _pwm, bool _isClockwise)
+  : Rotation(_pwm, _isClockwise), targetAngle(_targetAngle)
+{
+}
+
+bool PwmRotation::isMetPrecondition()
+{
+  const int BUF_SIZE = 256;
+  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+
+  // pwm値が0以下の場合はwarningを出して終了する
+  if(pwm <= 0) {
+    snprintf(buf, BUF_SIZE, "The pwm value passed to PwmRotation is %d", pwm);
+    // logger.logWarning(buf);
+    return false;
+  }
+
+  // targetAngleが0以下の場合はwarningを出して終了する
+  if(targetAngle <= 0 || targetAngle >= 360) {
+    snprintf(buf, BUF_SIZE, "The targetAngle value passed to PwmRotation is %d", targetAngle);
+    // logger.logWarning(buf);
+    return false;
+  }
+
+  return true;
+}
+
+bool PwmRotation::isMetPostcondition(double initLeftMileage, double initRightMileage, int leftSign,
+                                     int rightSign)
+{
+  // 指定した角度に対する目標の走行距離(弧の長さ)
+  double targetDistance = M_PI * TREAD * targetAngle / 360;
+
+  // 目標距離（呼び出し時の走行距離 ± 指定された回転量に必要な距離）
+  double targetLeftDistance = initLeftMileage + targetDistance * leftSign;
+  double targetRightDistance = initRightMileage + targetDistance * rightSign;
+
+  // 残りの移動距離を算出
+  double diffLeftDistance
+      = (targetLeftDistance - Mileage::calculateWheelMileage(measurer.getLeftCount())) * leftSign;
+  double diffRightDistance
+      = (targetRightDistance - Mileage::calculateWheelMileage(measurer.getRightCount()))
+        * rightSign;
+
+  // 目標距離に到達した場合
+  if(diffLeftDistance <= 0 && diffRightDistance <= 0) {
+    return false;
+  }
+  return true;
+}
+
+void PwmRotation::logRunning()
+{
+  const int BUF_SIZE = 256;
+  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+  const char* str = isClockwise ? "true" : "false";
+
+  snprintf(buf, BUF_SIZE, "Run PwmRotation (angle: %d, pwm: %d, isClockwise: %s)", targetAngle, pwm,
+           str);
+  //   logger.log(buf);
+}

--- a/module/Motion/PwmRotation.h
+++ b/module/Motion/PwmRotation.h
@@ -41,9 +41,6 @@ class PwmRotation : public Rotation {
    * @brief 実行のログを取る
    */
   void logRunning() override;
-
- private:
-  int targetAngle;  // 目標回転角度(deg) 0~360
 };
 
 #endif

--- a/module/Motion/PwmRotation.h
+++ b/module/Motion/PwmRotation.h
@@ -1,0 +1,49 @@
+/**
+ * @file   PwmRotation.h
+ * @brief  Pwm指定回頭動作
+ * @author takahashitom
+ */
+
+#ifndef PWMROTATION_H
+#define PWMROTATION_H
+
+#include "Rotation.h"
+
+class PwmRotation : public Rotation {
+ public:
+  /**
+   * コンストラクタ
+   * @param _targetAngle 目標回転角度(deg) 0~360
+   * @param _pwm PWM値 0~100
+   * @param _isClockwise 回頭方向 ture:時計回り, false:反時計回り
+   */
+  PwmRotation(int _targetAngle, int _pwm, bool _isClockwise);
+
+  /**
+   * @brief 回頭する
+   */
+  using Rotation::run;
+
+  /**
+   * @brief 回頭する際の事前条件判定をする
+   */
+  bool isMetPrecondition() override;
+
+  /**
+   * @brief 回頭する際の継続条件判定をする　返り値がfalseでモーターが止まる
+   * @param leftSign 左車輪の回転方向
+   * @param rightSign 右車輪の回転方向
+   */
+  bool isMetPostcondition(double initLeftMileage, double initRightMileage, int leftSign,
+                          int rightSign) override;
+
+  /**
+   * @brief 実行のログを取る
+   */
+  void logRunning() override;
+
+ private:
+  int targetAngle;  // 目標回転角度(deg) 0~360
+};
+
+#endif

--- a/module/Motion/PwmRotation.h
+++ b/module/Motion/PwmRotation.h
@@ -27,14 +27,14 @@ class PwmRotation : public Rotation {
   /**
    * @brief 回頭する際の事前条件判定をする
    */
-  bool isMetPrecondition() override;
+  bool isMetPreCondition() override;
 
   /**
    * @brief 回頭する際の継続条件判定をする　返り値がfalseでモーターが止まる
    * @param leftSign 左車輪の回転方向
    * @param rightSign 右車輪の回転方向
    */
-  bool isMetPostcondition(double initLeftMileage, double initRightMileage, int leftSign,
+  bool isMetContCondition(double initLeftMileage, double initRightMileage, int leftSign,
                           int rightSign) override;
 
   /**

--- a/module/Motion/Rotation.cpp
+++ b/module/Motion/Rotation.cpp
@@ -16,7 +16,7 @@ Rotation::Rotation(int _targetAngle, int _pwm, bool _isClockwise)
 void Rotation::run()
 {
   // 事前条件を判定する
-  if(!isMetPrecondition()) {
+  if(!isMetPreCondition()) {
     return;
   }
 
@@ -37,7 +37,7 @@ void Rotation::run()
   double targetRightDistance = initRightMileage + targetDistance * rightSign;
 
   // 継続条件を満たしている間ループ
-  while(isMetPostcondition(targetLeftDistance, targetRightDistance, leftSign, rightSign)) {
+  while(isMetContCondition(targetLeftDistance, targetRightDistance, leftSign, rightSign)) {
     // モータにPWM値をセット
     controller.setLeftMotorPwm(pwm * leftSign);
     controller.setRightMotorPwm(pwm * rightSign);

--- a/module/Motion/Rotation.cpp
+++ b/module/Motion/Rotation.cpp
@@ -1,0 +1,41 @@
+/**
+ * @file   Rotation.cpp
+ * @brief  回頭動作の中間クラス
+ * @author takahashitom
+ */
+
+#include "Rotation.h"
+
+using namespace std;
+
+Rotation::Rotation(int _pwm, bool _isClockwise) : pwm(_pwm), isClockwise(_isClockwise) {}
+
+void Rotation::run()
+{
+  // 事前条件を判定する
+  if(!isMetPrecondition()) {
+    return;
+  }
+
+  // isClockwiseがtrueなら時計回り，falseなら反時計回り
+  // isClockwiseは回転方向の係数
+  int leftSign = isClockwise ? 1 : -1;
+  int rightSign = isClockwise ? -1 : 1;
+
+  // 呼び出し時の走行距離
+  double initLeftMileage = Mileage::calculateWheelMileage(measurer.getLeftCount());
+  double initRightMileage = Mileage::calculateWheelMileage(measurer.getRightCount());
+
+  // 継続条件を満たしている間ループ
+  while(isMetPostcondition(initLeftMileage, initLeftMileage, leftSign, rightSign)) {
+    // モータにPWM値をセット
+    controller.setLeftMotorPwm(pwm * leftSign);
+    controller.setRightMotorPwm(pwm * rightSign);
+
+    // 10ミリ秒待機
+    timer.sleep();
+  }
+
+  // モータの停止
+  controller.stopMotor();
+}

--- a/module/Motion/Rotation.cpp
+++ b/module/Motion/Rotation.cpp
@@ -8,7 +8,10 @@
 
 using namespace std;
 
-Rotation::Rotation(int _pwm, bool _isClockwise) : pwm(_pwm), isClockwise(_isClockwise) {}
+Rotation::Rotation(int _targetAngle, int _pwm, bool _isClockwise)
+  : targetAngle(_targetAngle), pwm(_pwm), isClockwise(_isClockwise)
+{
+}
 
 void Rotation::run()
 {
@@ -26,8 +29,15 @@ void Rotation::run()
   double initLeftMileage = Mileage::calculateWheelMileage(measurer.getLeftCount());
   double initRightMileage = Mileage::calculateWheelMileage(measurer.getRightCount());
 
+  // 指定した角度に対する目標の走行距離(弧の長さ)
+  double targetDistance = M_PI * TREAD * targetAngle / 360;
+
+  // 目標距離（呼び出し時の走行距離 ± 指定された回転量に必要な距離）
+  double targetLeftDistance = initLeftMileage + targetDistance * leftSign;
+  double targetRightDistance = initRightMileage + targetDistance * rightSign;
+
   // 継続条件を満たしている間ループ
-  while(isMetPostcondition(initLeftMileage, initLeftMileage, leftSign, rightSign)) {
+  while(isMetPostcondition(targetLeftDistance, targetRightDistance, leftSign, rightSign)) {
     // モータにPWM値をセット
     controller.setLeftMotorPwm(pwm * leftSign);
     controller.setRightMotorPwm(pwm * rightSign);

--- a/module/Motion/Rotation.h
+++ b/module/Motion/Rotation.h
@@ -16,11 +16,11 @@ class Rotation : public Motion {
  public:
   /**
    * コンストラクタ
-   * @param _targetValue 目標値
+   * @param _targetAngle 目標回転角度(deg) 0~360
    * @param _pwm 指定するPWM値 0~100
    * @param _isClockwise 回頭方向 true:時計回り, false:反時計回り
    */
-  Rotation(int _pwm, bool _isClockwise);
+  Rotation(int _targetAngle, int _pwm, bool _isClockwise);
 
   /**
    * @brief 回頭する
@@ -35,12 +35,14 @@ class Rotation : public Motion {
 
   /**
    * @brief 回頭する際の継続条件判定をする　返り値がfalseでモーターが止まる
+   * @param targetLeftDistance 左車輪の目標距離
+   * @param targetRightDistance 右車輪の目標距離
    * @param leftSign 左車輪の回転方向
    * @param rightSign 右車輪の回転方向
    * @note オーバーライド必須
    */
-  virtual bool isMetPostcondition(double initLeftMileage, double initRightMileage, int leftSign,
-                                  int rightSign)
+  virtual bool isMetPostcondition(double targetLeftDistance, double targetRightDistance,
+                                  int leftSign, int rightSign)
       = 0;
 
   /**
@@ -50,6 +52,7 @@ class Rotation : public Motion {
   virtual void logRunning() = 0;
 
  protected:
+  int targetAngle;   // 目標回転角度(deg) 0~360
   int pwm;           // PWM値
   bool isClockwise;  // 回頭方向 true:時計回り, false:反時計回り
   Timer timer;

--- a/module/Motion/Rotation.h
+++ b/module/Motion/Rotation.h
@@ -1,0 +1,59 @@
+/**
+ * @file   Rotation.h
+ * @brief  回頭動作の中間クラス
+ * @author takahashitom
+ */
+
+#ifndef ROTATION_H
+#define ROTATION_H
+
+#include "Motion.h"
+#include "Mileage.h"
+#include "Timer.h"
+#include "SystemInfo.h"
+
+class Rotation : public Motion {
+ public:
+  /**
+   * コンストラクタ
+   * @param _targetValue 目標値
+   * @param _pwm 指定するPWM値 0~100
+   * @param _isClockwise 回頭方向 true:時計回り, false:反時計回り
+   */
+  Rotation(int _pwm, bool _isClockwise);
+
+  /**
+   * @brief 回頭する
+   */
+  void run();
+
+  /**
+   * @brief 回頭する際の事前条件判定をする
+   * @note オーバーライド必須
+   */
+  virtual bool isMetPrecondition() = 0;
+
+  /**
+   * @brief 回頭する際の継続条件判定をする　返り値がfalseでモーターが止まる
+   * @param leftSign 左車輪の回転方向
+   * @param rightSign 右車輪の回転方向
+   * @note オーバーライド必須
+   */
+  virtual bool isMetPostcondition(double initLeftMileage, double initRightMileage, int leftSign,
+                                  int rightSign)
+      = 0;
+
+  /**
+   * @brief 実行のログを取る
+   * @note オーバーライド必須
+   */
+  virtual void logRunning() = 0;
+
+ protected:
+  int pwm;           // PWM値
+  bool isClockwise;  // 回頭方向 true:時計回り, false:反時計回り
+  Timer timer;
+  Controller controller;
+  Measurer measurer;
+};
+#endif

--- a/module/Motion/Rotation.h
+++ b/module/Motion/Rotation.h
@@ -31,7 +31,7 @@ class Rotation : public Motion {
    * @brief 回頭する際の事前条件判定をする
    * @note オーバーライド必須
    */
-  virtual bool isMetPrecondition() = 0;
+  virtual bool isMetPreCondition() = 0;
 
   /**
    * @brief 回頭する際の継続条件判定をする　返り値がfalseでモーターが止まる
@@ -41,7 +41,7 @@ class Rotation : public Motion {
    * @param rightSign 右車輪の回転方向
    * @note オーバーライド必須
    */
-  virtual bool isMetPostcondition(double targetLeftDistance, double targetRightDistance,
+  virtual bool isMetContCondition(double targetLeftDistance, double targetRightDistance,
                                   int leftSign, int rightSign)
       = 0;
 

--- a/module/common/SystemInfo.h
+++ b/module/common/SystemInfo.h
@@ -1,7 +1,7 @@
 /**
  * @file SystemInfo.h
  * @brief 走行システムで統一する情報をまとめたファイル
- * @author desty505 bizyutyu
+ * @author takahashitom
  */
 
 #ifndef SYSTEM_INFO_H

--- a/module/common/SystemInfo.h
+++ b/module/common/SystemInfo.h
@@ -1,0 +1,21 @@
+/**
+ * @file SystemInfo.h
+ * @brief 走行システムで統一する情報をまとめたファイル
+ * @author desty505 bizyutyu
+ */
+
+#ifndef SYSTEM_INFO_H
+#define SYSTEM_INFO_H
+
+// ロボコンの部屋で取得した輝度
+static constexpr int BLACK_BRIGHTNESS = 3;   // 黒の輝度
+static constexpr int WHITE_BRIGHTNESS = 93;  // 白の輝度
+
+static constexpr double RADIUS = 50.0;  // 車輪の半径[mm]
+static constexpr double TREAD = 125.0;  // 走行体のトレッド幅（両輪の間の距離）[mm]
+
+static constexpr char RAS_PI_IP[16] = "172.20.1.1";
+
+static constexpr int ANGLE_SERVER_PORT = 10338;  // 角度算出用サーバのポート番号
+
+#endif

--- a/module/common/SystemInfo.h
+++ b/module/common/SystemInfo.h
@@ -7,15 +7,7 @@
 #ifndef SYSTEM_INFO_H
 #define SYSTEM_INFO_H
 
-// ロボコンの部屋で取得した輝度
-static constexpr int BLACK_BRIGHTNESS = 3;   // 黒の輝度
-static constexpr int WHITE_BRIGHTNESS = 93;  // 白の輝度
-
 static constexpr double RADIUS = 50.0;  // 車輪の半径[mm]
 static constexpr double TREAD = 125.0;  // 走行体のトレッド幅（両輪の間の距離）[mm]
-
-static constexpr char RAS_PI_IP[16] = "172.20.1.1";
-
-static constexpr int ANGLE_SERVER_PORT = 10338;  // 角度算出用サーバのポート番号
 
 #endif

--- a/test/PwmRotationTest.cpp
+++ b/test/PwmRotationTest.cpp
@@ -1,7 +1,7 @@
 /**
  * @file   PwmRotationTest.cpp
  * @brief  PwmRotationクラスのテスト
- * @author Negimarge
+ * @author takahashitom
  */
 
 #include "PwmRotation.h"

--- a/test/PwmRotationTest.cpp
+++ b/test/PwmRotationTest.cpp
@@ -81,6 +81,7 @@ namespace etrobocon2024_test {
     EXPECT_GE(expected + error, actual);
   }
 
+  // PWM値を0に設定して回頭するテスト
   TEST(PwmRotationTest, runZeroPWM)
   {
     Controller controller;
@@ -117,6 +118,7 @@ namespace etrobocon2024_test {
     EXPECT_EQ(expected, actual);  // 回頭の前後で角度に変化はない
   }
 
+  // PWM値をマイナスに設定して回頭するテスト
   TEST(PwmRotationTest, runMinusPWM)
   {
     Controller controller;
@@ -153,6 +155,7 @@ namespace etrobocon2024_test {
     EXPECT_EQ(expected, actual);  // 回頭の前後で角度に変化はない
   }
 
+  // 回頭角度を0に設定して回頭するテスト
   TEST(PwmRotationTest, runZeroAngle)
   {
     Controller controller;
@@ -189,6 +192,7 @@ namespace etrobocon2024_test {
     EXPECT_EQ(expected, actual);  // 回頭の前後で角度に変化はない
   }
 
+  // 回頭角度をマイナスに設定して回頭するテスト
   TEST(PwmRotationTest, runMinusAngle)
   {
     Controller controller;
@@ -225,6 +229,7 @@ namespace etrobocon2024_test {
     EXPECT_EQ(expected, actual);  // 回頭の前後で角度に変化はない
   }
 
+  // 回頭角度を360度以上に設定して回頭するテスト
   TEST(PwmRotationTest, runOverAngle)
   {
     Controller controller;

--- a/test/PwmRotationTest.cpp
+++ b/test/PwmRotationTest.cpp
@@ -1,0 +1,263 @@
+/**
+ * @file   PwmRotationTest.cpp
+ * @brief  PwmRotationクラスのテスト
+ * @author Negimarge
+ */
+
+#include "PwmRotation.h"
+#include <gtest/gtest.h>
+#include <cmath>
+#include <gtest/internal/gtest-port.h>
+
+using namespace std;
+
+namespace etrobocon2024_test {
+
+  // @see https://github.com/KatLab-MiyazakiUniv/etrobocon2022/blob/main/docs/odometry.md
+  constexpr double TRANSFORM = 2.0 * RADIUS / TREAD;  // 回頭角度を求める式の係数
+
+  // 右回頭のテスト
+  TEST(PwmRotationTest, runRight)
+  {
+    Measurer measurer;
+    int angle = 90;
+    int pwm = 100;
+    bool isClockwise = true;
+    PwmRotation PwmRotation(angle, pwm, isClockwise);
+
+    double expected = angle;  // 指定した回頭角度を期待値とする
+
+    // 一回のsetPWM()でダミーのモータカウントに加算される値はpwm * 0.05
+    double error = pwm * 0.05 * TRANSFORM;  // 許容誤差[deg]
+
+    // 回頭前のモータカウント
+    int initialRightMotorCount = measurer.getRightCount();
+    int initialLeftMotorCount = measurer.getLeftCount();
+
+    testing::internal::CaptureStdout();                      // 標準出力キャプチャ開始
+    PwmRotation.run();                                       // 右回頭を実行
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // 回頭後に各モータが回転した角度
+    int rightMotorCount = abs(measurer.getRightCount() - initialRightMotorCount);
+    int leftMotorCount = abs(measurer.getLeftCount() - initialLeftMotorCount);
+    double actual = ((rightMotorCount + leftMotorCount) * TRANSFORM) / 2;
+
+    EXPECT_LE(expected, actual);
+    EXPECT_GE(expected + error, actual);
+  }
+
+  // 左回頭のテスト
+  TEST(PwmRotationTest, runLeft)
+  {
+    Controller controller;
+    controller.resetRightMotorPwm();
+    controller.resetLeftMotorPwm();
+
+    Measurer measurer;
+    int angle = 180;
+    int pwm = 100;
+    bool isClockwise = false;
+    PwmRotation PwmRotation(angle, pwm, isClockwise);
+
+    double expected = angle;  // 指定した回頭角度を期待値とする
+
+    // 一回のsetPWM()でダミーのモータカウントに加算される値はpwm * 0.05
+    double error = pwm * 0.05 * TRANSFORM;  // 許容誤差[deg]
+
+    // 回頭前のモータカウント
+    int initialRightMotorCount = measurer.getRightCount();
+    int initialLeftMotorCount = measurer.getLeftCount();
+
+    PwmRotation.run();  // 左回頭を実行
+
+    // 回頭後に各モータが回転した角度
+    int rightMotorCount = abs(measurer.getRightCount() - initialRightMotorCount);
+    int leftMotorCount = abs(measurer.getLeftCount() - initialLeftMotorCount);
+
+    double actual = ((rightMotorCount + leftMotorCount) * TRANSFORM) / 2;
+
+    EXPECT_LE(expected, actual);
+    EXPECT_GE(expected + error, actual);
+  }
+
+  TEST(PwmRotationTest, runZeroPWM)
+  {
+    Controller controller;
+    controller.resetRightMotorPwm();
+    controller.resetLeftMotorPwm();
+
+    Measurer measurer;
+    int angle = 45;
+    int pwm = 0;
+    bool isClockwise = true;
+    PwmRotation PwmRotation(angle, pwm, isClockwise);
+
+    double expected = 0;  // 回頭しない
+
+    // Warning文
+    string expectedOutput = "\x1b[36m";  // 文字色をシアンに
+    expectedOutput += "Warning: The pwm value passed to PwmRotation is 0";
+    expectedOutput += "\n\x1b[39m";  // 文字色をデフォルトに戻す
+
+    // 回頭前のモータカウント
+    int initialRightMotorCount = measurer.getRightCount();
+    int initialLeftMotorCount = measurer.getLeftCount();
+
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    PwmRotation.run();                   // 右回頭を実行
+    string actualOutput = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // 回頭後に各モータが回転した角度
+    int rightMotorCount = abs(measurer.getRightCount() - initialRightMotorCount);
+    int leftMotorCount = abs(measurer.getLeftCount() - initialLeftMotorCount);
+    double actual = ((rightMotorCount + leftMotorCount) * TRANSFORM) / 2;
+
+    // EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
+    EXPECT_EQ(expected, actual);  // 回頭の前後で角度に変化はない
+  }
+
+  TEST(PwmRotationTest, runMinusPWM)
+  {
+    Controller controller;
+    controller.resetRightMotorPwm();
+    controller.resetLeftMotorPwm();
+
+    Measurer measurer;
+    int angle = 45;
+    int pwm = -100;
+    bool isClockwise = true;
+    PwmRotation PwmRotation(angle, pwm, isClockwise);
+
+    double expected = 0;  // 回頭しない
+
+    // Warning文
+    string expectedOutput = "\x1b[36m";  // 文字色をシアンに
+    expectedOutput += "Warning: The pwm value passed to PwmRotation is " + to_string(pwm);
+    expectedOutput += "\n\x1b[39m";  // 文字色をデフォルトに戻す
+
+    // 回頭前のモータカウント
+    int initialRightMotorCount = measurer.getRightCount();
+    int initialLeftMotorCount = measurer.getLeftCount();
+
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    PwmRotation.run();                   // 右回頭を実行
+    string actualOutput = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // 回頭後に各モータが回転した角度
+    int rightMotorCount = abs(measurer.getRightCount() - initialRightMotorCount);
+    int leftMotorCount = abs(measurer.getLeftCount() - initialLeftMotorCount);
+    double actual = ((rightMotorCount + leftMotorCount) * TRANSFORM) / 2;
+
+    // EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
+    EXPECT_EQ(expected, actual);  // 回頭の前後で角度に変化はない
+  }
+
+  TEST(PwmRotationTest, runZeroAngle)
+  {
+    Controller controller;
+    controller.resetRightMotorPwm();
+    controller.resetLeftMotorPwm();
+
+    Measurer measurer;
+    int angle = 0;
+    int pwm = 100;
+    bool isClockwise = true;
+    PwmRotation PwmRotation(angle, pwm, isClockwise);
+
+    double expected = 0;  // 回頭しない
+
+    // Warning文
+    string expectedOutput = "\x1b[36m";  // 文字色をシアンに
+    expectedOutput += "Warning: The angle value passed to PwmRotation is 0";
+    expectedOutput += "\n\x1b[39m";  // 文字色をデフォルトに戻す
+
+    // 回頭前のモータカウント
+    int initialRightMotorCount = measurer.getRightCount();
+    int initialLeftMotorCount = measurer.getLeftCount();
+
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    PwmRotation.run();                   // 右回頭を実行
+    string actualOutput = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // 回頭後に各モータが回転した角度
+    int rightMotorCount = abs(measurer.getRightCount() - initialRightMotorCount);
+    int leftMotorCount = abs(measurer.getLeftCount() - initialLeftMotorCount);
+    double actual = ((rightMotorCount + leftMotorCount) * TRANSFORM) / 2;
+
+    // EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
+    EXPECT_EQ(expected, actual);  // 回頭の前後で角度に変化はない
+  }
+
+  TEST(PwmRotationTest, runMinusAngle)
+  {
+    Controller controller;
+    controller.resetRightMotorPwm();
+    controller.resetLeftMotorPwm();
+
+    Measurer measurer;
+    int angle = -180;
+    int pwm = 100;
+    bool isClockwise = true;
+    PwmRotation PwmRotation(angle, pwm, isClockwise);
+
+    double expected = 0;  // 回頭しない
+
+    // Warning文
+    string expectedOutput = "\x1b[36m";  // 文字色をシアンに
+    expectedOutput += "Warning: The angle value passed to PwmRotation is " + to_string(angle);
+    expectedOutput += "\n\x1b[39m";  // 文字色をデフォルトに戻す
+
+    // 回頭前のモータカウント
+    int initialRightMotorCount = measurer.getRightCount();
+    int initialLeftMotorCount = measurer.getLeftCount();
+
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    PwmRotation.run();                   // 右回頭を実行
+    string actualOutput = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // 回頭後に各モータが回転した角度
+    int rightMotorCount = abs(measurer.getRightCount() - initialRightMotorCount);
+    int leftMotorCount = abs(measurer.getLeftCount() - initialLeftMotorCount);
+    double actual = ((rightMotorCount + leftMotorCount) * TRANSFORM) / 2;
+
+    // EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
+    EXPECT_EQ(expected, actual);  // 回頭の前後で角度に変化はない
+  }
+
+  TEST(PwmRotationTest, runOverAngle)
+  {
+    Controller controller;
+    controller.resetRightMotorPwm();
+    controller.resetLeftMotorPwm();
+
+    Measurer measurer;
+    int angle = 360;
+    int pwm = 100;
+    bool isClockwise = true;
+    PwmRotation PwmRotation(angle, pwm, isClockwise);
+
+    double expected = 0;  // 回頭しない
+
+    // Warning文
+    string expectedOutput = "\x1b[36m";  // 文字色をシアンに
+    expectedOutput += "Warning: The angle value passed to PwmRotation is " + to_string(angle);
+    expectedOutput += "\n\x1b[39m";  // 文字色をデフォルトに戻す
+
+    // 回頭前のモータカウント
+    int initialRightMotorCount = measurer.getRightCount();
+    int initialLeftMotorCount = measurer.getLeftCount();
+
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    PwmRotation.run();                   // 右回頭を実行
+    string actualOutput = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // 回頭後に各モータが回転した角度
+    int rightMotorCount = abs(measurer.getRightCount() - initialRightMotorCount);
+    int leftMotorCount = abs(measurer.getLeftCount() - initialLeftMotorCount);
+    double actual = ((rightMotorCount + leftMotorCount) * TRANSFORM) / 2;
+
+    // EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
+    EXPECT_EQ(expected, actual);  // 回頭の前後で角度に変化はない
+  }
+}  // namespace etrobocon2024_test


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点

角度とPWM値を指定して回頭動作を行うための親クラスを定義したソースファイルを、module/Motionに追加
- Rotation.h
- Rotation.cpp

角度とPWM値を指定して回頭動作を行うための子クラスを定義したソースファイルを、module/Motionに追加
- PwmRotation.h
- PwmRotation.cpp

走行システムで統一する情報をまとめたファイルを、module/commonに追加
- SystemInfo.h

Rotationクラス、PwmRotationクラスのテストファイルを、testに追加
- PwmRotationTest.cpp

# 動作テスト
https://www.notion.so/uom-katlab/d16c1efb8c7f4842a41fa9a2ca9ca014?pvs=4#6c803151e9a7433e933aee41fa186fdc

## 実験結果
角度、PWM値を設定し、回頭動作を行うことができた。
布面上ではタイヤが上手く回転せずに、動作にずれが生じてしまう場合があることが確認された。

# メモ
loggerを必要とする処理はコメントアウトしています。
loggerがマージされた後、コメントアウトを解除して改めて動作確認します。