### PR TITLE
close #KLI-77 Loggerの実装

### DIFF
--- a/module/Motion/Motion.h
+++ b/module/Motion/Motion.h
@@ -9,7 +9,7 @@
 
 #include "Measurer.h"
 #include "Controller.h"
-// #include "Logger.h"
+#include "Logger.h"
 
 class Motion {
  public:
@@ -29,7 +29,7 @@ class Motion {
   virtual void logRunning() = 0;
 
  protected:
-  // Logger logger;
+  Logger logger;
 };
 
 #endif

--- a/module/common/Logger.cpp
+++ b/module/common/Logger.cpp
@@ -1,0 +1,81 @@
+/**
+ * @file Logger.cpp
+ * @brief 動作確認に用いるprintf()関数を所持するクラス
+ * @author YKhm20020
+ */
+#include "Logger.h"
+
+Logger::Logger() {}
+
+void Logger::log(const char* logMessage)
+{
+  const int BUF_SIZE = 256;
+  char message[BUF_SIZE];  // 表示するメッセージ
+  snprintf(message, BUF_SIZE, "%s\n", logMessage);
+  printf("%s", message);
+
+  strncat(logs, message, sizeof(logs));  // logsとmessageを結合する
+}
+
+void Logger::logWarning(const char* warningMessage)
+{
+  const int BUF_SIZE = 128;
+  char message[BUF_SIZE];  // 表示するメッセージ
+  snprintf(message, BUF_SIZE, "%s\n", warningMessage);
+  printf("\x1b[36m"); /* 文字色をシアンに */
+  printf("Warning: %s", message);
+  printf("\x1b[39m"); /* 文字色をデフォルトに戻す */
+
+  strncat(logs, message, sizeof(logs));  // logsとmessageを結合する
+}
+
+void Logger::logError(const char* errorMessage)
+{
+  const int BUF_SIZE = 128;
+  char message[BUF_SIZE];  // 表示するメッセージ
+  snprintf(message, BUF_SIZE, "%s\n", errorMessage);
+  printf("\x1b[35m"); /* 文字色をマゼンタに */
+  printf("Error: %s", message);
+  printf("\x1b[39m"); /* 文字色をデフォルトに戻す */
+
+  strncat(logs, message, sizeof(logs));  // logsとmessageを結合する
+}
+
+void Logger::logHighlight(const char* highlightLog)
+{
+  const int BUF_SIZE = 128;
+  char message[BUF_SIZE];  // 表示するメッセージ
+  snprintf(message, BUF_SIZE, "%s\n", highlightLog);
+  printf("\x1b[32m"); /* 文字色を緑色に */
+  printf("%s", message);
+  printf("\x1b[39m"); /* 文字色をデフォルトに戻す */
+
+  strncat(logs, message, sizeof(logs));  // logsとmessageを結合する
+}
+
+void Logger::outputToFile()
+{
+  FILE* outputFile;
+  const char* fileName = "logfile.txt";  // 暫定のファイル名
+  outputFile = fopen(fileName, "w");     // logfile.txtを作成
+  if(outputFile == NULL) {
+    logWarning("cannot open file");
+    return;
+  }
+  fprintf(outputFile, "%s", logs);  // logsの内容をlogfile.txtに書き込む
+  fclose(outputFile);
+
+  /*
+  NOTE: ロボコン環境だと，時刻を取得するtime.hのtime()や，
+  ディレクトリを生成するためのヘッダdirect.hを使用できないため（多分），
+  bashでlogfile.txtの名前をログ生成時刻に変更し，logfiles/に移動する
+  */
+  system("bash ./etrobocon2024/scripts/organize_logfile.sh");
+}
+
+void Logger::initLogs()
+{
+  logs[0] = '\0';  // 文字列を初期化
+}
+
+char Logger::logs[65536] = "";  // logsを初期化

--- a/module/common/Logger.cpp
+++ b/module/common/Logger.cpp
@@ -5,13 +5,16 @@
  */
 #include "Logger.h"
 
+// NOTE: メモリ領域不足によってログが全て表示できない場合があるため、大きめのメモリ領域を別に確保
+#define LARGE_BUF_SIZE 256
+#define SMALL_BUF_SIZE 128
+
 Logger::Logger() {}
 
 void Logger::log(const char* logMessage)
 {
-  const int BUF_SIZE = 256;
-  char message[BUF_SIZE];  // 表示するメッセージ
-  snprintf(message, BUF_SIZE, "%s\n", logMessage);
+  char message[LARGE_BUF_SIZE];  // 表示するメッセージ
+  snprintf(message, LARGE_BUF_SIZE, "%s\n", logMessage);
   printf("%s", message);
 
   strncat(logs, message, sizeof(logs));  // logsとmessageを結合する
@@ -19,9 +22,8 @@ void Logger::log(const char* logMessage)
 
 void Logger::logWarning(const char* warningMessage)
 {
-  const int BUF_SIZE = 128;
-  char message[BUF_SIZE];  // 表示するメッセージ
-  snprintf(message, BUF_SIZE, "%s\n", warningMessage);
+  char message[SMALL_BUF_SIZE];  // 表示するメッセージ
+  snprintf(message, SMALL_BUF_SIZE, "%s\n", warningMessage);
   printf("\x1b[36m"); /* 文字色をシアンに */
   printf("Warning: %s", message);
   printf("\x1b[39m"); /* 文字色をデフォルトに戻す */
@@ -31,9 +33,8 @@ void Logger::logWarning(const char* warningMessage)
 
 void Logger::logError(const char* errorMessage)
 {
-  const int BUF_SIZE = 128;
-  char message[BUF_SIZE];  // 表示するメッセージ
-  snprintf(message, BUF_SIZE, "%s\n", errorMessage);
+  char message[SMALL_BUF_SIZE];  // 表示するメッセージ
+  snprintf(message, SMALL_BUF_SIZE, "%s\n", errorMessage);
   printf("\x1b[35m"); /* 文字色をマゼンタに */
   printf("Error: %s", message);
   printf("\x1b[39m"); /* 文字色をデフォルトに戻す */
@@ -43,9 +44,8 @@ void Logger::logError(const char* errorMessage)
 
 void Logger::logHighlight(const char* highlightLog)
 {
-  const int BUF_SIZE = 128;
-  char message[BUF_SIZE];  // 表示するメッセージ
-  snprintf(message, BUF_SIZE, "%s\n", highlightLog);
+  char message[SMALL_BUF_SIZE];  // 表示するメッセージ
+  snprintf(message, SMALL_BUF_SIZE, "%s\n", highlightLog);
   printf("\x1b[32m"); /* 文字色を緑色に */
   printf("%s", message);
   printf("\x1b[39m"); /* 文字色をデフォルトに戻す */

--- a/module/common/Logger.h
+++ b/module/common/Logger.h
@@ -12,6 +12,9 @@
 
 class Logger {
  public:
+  /**
+   * コンストラクタ
+   */
   Logger();
 
   /**

--- a/module/common/Logger.h
+++ b/module/common/Logger.h
@@ -34,7 +34,7 @@ class Logger {
 
   /**
    * @brief 入力された文字列をhighlightLogとして色を変更し、ターミナルに表示
-   * @param hilightLog 表示するhighlightlogメッセージ
+   * @param highlightLog 表示するhighlightlogメッセージ
    */
   void logHighlight(const char* highlightLog);
 

--- a/module/common/Logger.h
+++ b/module/common/Logger.h
@@ -1,0 +1,55 @@
+/**
+ * @file Logger.h
+ * @brief 動作確認に用いるprintf()関数を所持するクラス
+ * @author YKhm20020
+ */
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+class Logger {
+ public:
+  Logger();
+
+  /**
+   * @brief 入力された文字列をLogとしてターミナルに表示
+   * @param logMessage 表示するLogメッセージ
+   */
+  void log(const char* logMessage);
+
+  /**
+   * @brief 入力された文字列をwarningMessageとして色を変更し、ターミナルに表示
+   * @param warningMessage 表示するwarningメッセージ
+   */
+  void logWarning(const char* warningMessage);
+
+  /**
+   * @brief 入力された文字列をerrorMessageとして色を変更し、ターミナルに表示
+   * @param errorMessage 表示するerrorメッセージ
+   */
+  void logError(const char* errorMessage);
+
+  /**
+   * @brief 入力された文字列をhighlightLogとして色を変更し、ターミナルに表示
+   * @param hilightLog 表示するhighlightlogメッセージ
+   */
+  void logHighlight(const char* highlightLog);
+
+  /**
+   * @brief 記録したログをファイル出力する
+   */
+  void outputToFile();
+
+  /**
+   * @brief 記録したログを初期化する
+   */
+  void initLogs();
+
+ private:
+  static char logs[65536];  // システムのログを保持する領域
+};
+
+#endif

--- a/scripts/organize_logfile.sh
+++ b/scripts/organize_logfile.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+<<DOCUMENT_COMMENT
+@file   organize_logfile.sh
+@brief  前回のログファイルを退避する
+@author YKhm20020
+DOCUMENT_COMMENT
+
+mkdir -p etrobocon2024/logfiles
+oldName="logfile.txt"
+newName=`date +"%m%d-%H:%M.txt"`
+
+mv -f $oldName etrobocon2024/logfiles/$newName

--- a/test/LoggerTest.cpp
+++ b/test/LoggerTest.cpp
@@ -1,0 +1,112 @@
+/**
+ * @file LoggerTest.cpp
+ * @brief Loggerクラスをテストする
+ * @author YKhm20020
+ */
+
+#include "Logger.h"
+#include <gtest/gtest.h>
+#include <gtest/internal/gtest-port.h>
+#include <err.h>
+
+namespace etrobocon2024_test {
+  TEST(LoggerTest, log)
+  {
+    Logger logger;
+    std::string logMsg = "logs test.";
+    std::string expected = logMsg + "\n";
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    logger.log(logMsg.c_str());
+    std::string actual = testing::internal::GetCapturedStdout();  // キャプチャ終了
+    ASSERT_STREQ(expected.c_str(), actual.c_str());
+  }
+
+  TEST(LoggerTest, logWarning)
+  {
+    Logger logger;
+    std::string logMsg = "WarningMessage test.";
+    std::string expected = "\x1b[36m";  // 文字色をシアンに
+    expected += "Warning: " + logMsg + "\n";
+    expected += "\x1b[39m";              // 文字色をデフォルトに戻す
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    logger.logWarning(logMsg.c_str());
+    std::string actual = testing::internal::GetCapturedStdout();  // キャプチャ終了
+    ASSERT_STREQ(expected.c_str(), actual.c_str());
+  }
+
+  TEST(LoggerTest, logError)
+  {
+    Logger logger;
+    std::string logMsg = "ErrorMessage test.";
+    std::string expected = "\x1b[35m";  // 文字色をマゼンタに
+    expected += "Error: " + logMsg + "\n";
+    expected += "\x1b[39m";              // 文字色をデフォルトに戻す
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    logger.logError(logMsg.c_str());
+    std::string actual = testing::internal::GetCapturedStdout();  // キャプチャ終了
+    ASSERT_STREQ(expected.c_str(), actual.c_str());
+  }
+
+  TEST(LoggerTest, logHighlight)
+  {
+    Logger logger;
+    std::string logMsg = "HighlightLog test.";
+    std::string expected = "\x1b[32m";  // 文字色を緑色に
+    expected += logMsg + "\n";
+    expected += "\x1b[39m";              // 文字色をデフォルトに戻す
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    logger.logHighlight(logMsg.c_str());
+    std::string actual = testing::internal::GetCapturedStdout();  // キャプチャ終了
+    ASSERT_STREQ(expected.c_str(), actual.c_str());
+  }
+
+  TEST(LoggerTest, outputToFile)
+  {
+    // 異なるLoggerインスタンスを用いてログを取る
+    Logger logger1;
+    Logger logger2;
+    logger1.initLogs();  // logsを初期化
+    // 各ログ出力の関数を実行する
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    logger1.log("log text");
+    logger2.logWarning("log warning-text");
+    logger1.logError("log error-text");
+    logger2.logHighlight("log highlight-text");
+    std::string _ = testing::internal::GetCapturedStdout();  // キャプチャ終了
+    // 期待出力をセットする
+    std::string expected = "log text\n";
+    expected += "log warning-text\n";
+    expected += "log error-text\n";
+    expected += "log highlight-text\n";
+
+    logger1.outputToFile();  // ログファイルを生成
+
+    const int BUF_SIZE = 64;
+    char filePath[BUF_SIZE] = "./etrobocon2024/logfiles/";
+    char fileName[BUF_SIZE];  // outputToFile()で作成したログファイル
+    const char* cmdline = "ls -rt ./etrobocon2024/logfiles | tail -n 1";
+    FILE* fp = popen(cmdline, "r");  // 上記コマンドにより最新のログファイルを取得する
+    // コマンドの実行結果を取得出来ない場合エラーを出す
+    if((fp = popen(cmdline, "r")) == NULL) {
+      err(EXIT_FAILURE, "%s", cmdline);
+    }
+    fgets(fileName, BUF_SIZE, fp);  // コマンドの実行結果をfileNameにセット
+    pclose(fp);
+    char* endPoint = strchr(fileName, '\n');        // 改行があるポインタを取得
+    if(endPoint != NULL) *endPoint = '\0';          // 改行を削除
+    strncat(filePath, fileName, sizeof(filePath));  // filePathとfileNameを結合する
+
+    const int LINE_SIZE = 256;
+    char line[LINE_SIZE];
+    FILE* file = fopen(filePath, "r");
+    // 直前に生成したログファイルの文字列をセットする
+    std::string actual = "";
+    while(fgets(line, LINE_SIZE, file) != NULL) {
+      actual += line;
+    }
+    fclose(file);
+
+    ASSERT_STREQ(expected.c_str(), actual.c_str());  // ログファイルの中身をテスト
+  }
+
+}  // namespace etrobocon2024_test

--- a/test/gtest/gtest_build.sh
+++ b/test/gtest/gtest_build.sh
@@ -25,9 +25,9 @@ mkdir -p build/etrobocon2024/logfiles
 mkdir -p build/etrobocon2024/scripts
 mkdir -p build/etrobocon2024/datafiles
 cd build
-# cp ../scripts/*.sh etrobocon2024/scripts/
+cp ../scripts/*.sh etrobocon2024/scripts/
 # cp ../datafiles/*.csv etrobocon2024/datafiles/
-# chmod 777 ./etrobocon2024/scripts/*.sh
+chmod 777 ./etrobocon2024/scripts/*.sh
 
 cmake -DCMAKE_BUILD_TYPE=Coverage ..
 cmake --build .


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
動作のログを出力するクラス Logger.cpp, Logger.h を module/common 下に追加。
また、対応するテスト LoggerTest.cpp を test 下に追加。
前回のログを保存する organization_logfile.sh を追加し、テスト実行の際にディレクトリが異なることでテストが通らない問題を解消するよう、gtest_build.sh のコメントを解除。

# 動作テスト
実機での動作チェックができていません。
今メインブランチにある分で Logger を使うのが、Motion の親クラスだけだったので、現状動かせるクラスがないという状態です。
このブランチをマージ後、次イテレーションで子クラスを実機で動作確認する際に、一緒に使っていただければと思います。

## 添付資料
