### PR TITLE
close #KLI-86 PWM指定回頭にloggerを適用する

### DIFF
--- a/module/Calculator/SpeedCalculator.h
+++ b/module/Calculator/SpeedCalculator.h
@@ -7,11 +7,11 @@
 #ifndef SpeedCalculator_H
 #define SpeedCalculator_H
 
+#include "Measurer.h"
+#include "Controller.h"
 #include "Mileage.h"
 #include "Pid.h"
 #include "Timer.h"
-#include "Controller.h"
-#include "Measurer.h"
 
 class SpeedCalculator {
  public:

--- a/module/Motion/PwmRotation.cpp
+++ b/module/Motion/PwmRotation.cpp
@@ -15,20 +15,19 @@ PwmRotation::PwmRotation(int _targetAngle, int _pwm, bool _isClockwise)
 
 bool PwmRotation::isMetPreCondition()
 {
-  const int BUF_SIZE = 256;
-  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+  char buf[LARGE_BUF_SIZE];  // log用にメッセージを一時保持する領域
 
   // pwm値が0以下の場合はwarningを出して終了する
   if(pwm <= 0) {
-    snprintf(buf, BUF_SIZE, "The pwm value passed to PwmRotation is %d", pwm);
-    // logger.logWarning(buf);
+    snprintf(buf, LARGE_BUF_SIZE, "The pwm value passed to PwmRotation is %d", pwm);
+    logger.logWarning(buf);
     return false;
   }
 
   // targetAngleが0以下の場合はwarningを出して終了する
   if(targetAngle <= 0 || targetAngle >= 360) {
-    snprintf(buf, BUF_SIZE, "The targetAngle value passed to PwmRotation is %d", targetAngle);
-    // logger.logWarning(buf);
+    snprintf(buf, LARGE_BUF_SIZE, "The angle value passed to PwmRotation is %d", targetAngle);
+    logger.logWarning(buf);
     return false;
   }
 
@@ -54,11 +53,10 @@ bool PwmRotation::isMetContCondition(double targetLeftDistance, double targetRig
 
 void PwmRotation::logRunning()
 {
-  const int BUF_SIZE = 256;
-  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+  char buf[LARGE_BUF_SIZE];  // log用にメッセージを一時保持する領域
   const char* str = isClockwise ? "true" : "false";
 
-  snprintf(buf, BUF_SIZE, "Run PwmRotation (angle: %d, pwm: %d, isClockwise: %s)", targetAngle, pwm,
-           str);
-  //   logger.log(buf);
+  snprintf(buf, LARGE_BUF_SIZE, "Run PwmRotation (angle: %d, pwm: %d, isClockwise: %s)",
+           targetAngle, pwm, str);
+  logger.log(buf);
 }

--- a/module/Motion/PwmRotation.cpp
+++ b/module/Motion/PwmRotation.cpp
@@ -15,18 +15,18 @@ PwmRotation::PwmRotation(int _targetAngle, int _pwm, bool _isClockwise)
 
 bool PwmRotation::isMetPreCondition()
 {
-  char buf[LARGE_BUF_SIZE];  // log用にメッセージを一時保持する領域
+  char buf[SMALL_BUF_SIZE];  // log用にメッセージを一時保持する領域
 
   // pwm値が0以下の場合はwarningを出して終了する
   if(pwm <= 0) {
-    snprintf(buf, LARGE_BUF_SIZE, "The pwm value passed to PwmRotation is %d", pwm);
+    snprintf(buf, SMALL_BUF_SIZE, "The pwm value passed to PwmRotation is %d", pwm);
     logger.logWarning(buf);
     return false;
   }
 
   // targetAngleが0以下の場合はwarningを出して終了する
   if(targetAngle <= 0 || targetAngle >= 360) {
-    snprintf(buf, LARGE_BUF_SIZE, "The angle value passed to PwmRotation is %d", targetAngle);
+    snprintf(buf, SMALL_BUF_SIZE, "The angle value passed to PwmRotation is %d", targetAngle);
     logger.logWarning(buf);
     return false;
   }
@@ -53,10 +53,10 @@ bool PwmRotation::isMetContCondition(double targetLeftDistance, double targetRig
 
 void PwmRotation::logRunning()
 {
-  char buf[LARGE_BUF_SIZE];  // log用にメッセージを一時保持する領域
+  char buf[SMALL_BUF_SIZE];  // log用にメッセージを一時保持する領域
   const char* str = isClockwise ? "true" : "false";
 
-  snprintf(buf, LARGE_BUF_SIZE, "Run PwmRotation (angle: %d, pwm: %d, isClockwise: %s)",
+  snprintf(buf, SMALL_BUF_SIZE, "Run PwmRotation (angle: %d, pwm: %d, isClockwise: %s)",
            targetAngle, pwm, str);
   logger.log(buf);
 }

--- a/module/common/Logger.cpp
+++ b/module/common/Logger.cpp
@@ -5,10 +5,6 @@
  */
 #include "Logger.h"
 
-// NOTE: メモリ領域不足によってログが全て表示できない場合があるため、大きめのメモリ領域を別に確保
-#define LARGE_BUF_SIZE 256
-#define SMALL_BUF_SIZE 128
-
 Logger::Logger() {}
 
 void Logger::log(const char* logMessage)

--- a/module/common/Logger.h
+++ b/module/common/Logger.h
@@ -10,6 +10,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+// NOTE: メモリ領域不足によってログが全て表示できない場合があるため、大きめのメモリ領域を別に確保
+#define LARGE_BUF_SIZE 256
+#define SMALL_BUF_SIZE 128
+
 class Logger {
  public:
   /**

--- a/test/PwmRotationTest.cpp
+++ b/test/PwmRotationTest.cpp
@@ -114,8 +114,8 @@ namespace etrobocon2024_test {
     int leftMotorCount = abs(measurer.getLeftCount() - initialLeftMotorCount);
     double actual = ((rightMotorCount + leftMotorCount) * TRANSFORM) / 2;
 
-    // EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
-    EXPECT_EQ(expected, actual);  // 回頭の前後で角度に変化はない
+    EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
+    EXPECT_EQ(expected, actual);              // 回頭の前後で角度に変化はない
   }
 
   // PWM値をマイナスに設定して回頭するテスト
@@ -151,8 +151,8 @@ namespace etrobocon2024_test {
     int leftMotorCount = abs(measurer.getLeftCount() - initialLeftMotorCount);
     double actual = ((rightMotorCount + leftMotorCount) * TRANSFORM) / 2;
 
-    // EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
-    EXPECT_EQ(expected, actual);  // 回頭の前後で角度に変化はない
+    EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
+    EXPECT_EQ(expected, actual);              // 回頭の前後で角度に変化はない
   }
 
   // 回頭角度を0に設定して回頭するテスト
@@ -188,8 +188,8 @@ namespace etrobocon2024_test {
     int leftMotorCount = abs(measurer.getLeftCount() - initialLeftMotorCount);
     double actual = ((rightMotorCount + leftMotorCount) * TRANSFORM) / 2;
 
-    // EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
-    EXPECT_EQ(expected, actual);  // 回頭の前後で角度に変化はない
+    EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
+    EXPECT_EQ(expected, actual);              // 回頭の前後で角度に変化はない
   }
 
   // 回頭角度をマイナスに設定して回頭するテスト
@@ -225,8 +225,8 @@ namespace etrobocon2024_test {
     int leftMotorCount = abs(measurer.getLeftCount() - initialLeftMotorCount);
     double actual = ((rightMotorCount + leftMotorCount) * TRANSFORM) / 2;
 
-    // EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
-    EXPECT_EQ(expected, actual);  // 回頭の前後で角度に変化はない
+    EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
+    EXPECT_EQ(expected, actual);              // 回頭の前後で角度に変化はない
   }
 
   // 回頭角度を360度以上に設定して回頭するテスト
@@ -262,7 +262,7 @@ namespace etrobocon2024_test {
     int leftMotorCount = abs(measurer.getLeftCount() - initialLeftMotorCount);
     double actual = ((rightMotorCount + leftMotorCount) * TRANSFORM) / 2;
 
-    // EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
-    EXPECT_EQ(expected, actual);  // 回頭の前後で角度に変化はない
+    EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
+    EXPECT_EQ(expected, actual);              // 回頭の前後で角度に変化はない
   }
 }  // namespace etrobocon2024_test


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- module/Motion/PwmRotation.cpp 内のロガーに関する処理のコメントアウトを解除
- bufsize を define で宣言するようにしたため、module/common/Logger.h で宣言された bufsize を使用するようにした

# 動作テスト
https://www.notion.so/uom-katlab/PWM-logger-383ca8d4c90b41b9a74a0a8aa9019d17?pvs=4#211e9e84bb3f461484f17a9e5c2eed50

## 実験方法
わざとWarning文が表示される入力を実機上で行い、きちんとWarning文が表示されるか確認した。

## 実験結果
Warning文が表示された。
