### PR TITLE
close #KLI-adjustment 攻略エリアの再定義および各攻略エリアのサンプルCSVを追加

### DIFF
--- a/datafiles/DebrisRemovalLeft.csv
+++ b/datafiles/DebrisRemovalLeft.csv
@@ -1,0 +1,1 @@
+AR,90,100,clockwise,Google Testパス用のサンプル

--- a/datafiles/DebrisRemovalRight.csv
+++ b/datafiles/DebrisRemovalRight.csv
@@ -1,0 +1,1 @@
+AR,90,100,clockwise,Google Testパス用のサンプル

--- a/datafiles/DoubleLoopLeft.csv
+++ b/datafiles/DoubleLoopLeft.csv
@@ -1,0 +1,1 @@
+AR,90,100,clockwise,Google Testパス用のサンプル

--- a/datafiles/DoubleLoopRight.csv
+++ b/datafiles/DoubleLoopRight.csv
@@ -1,0 +1,1 @@
+AR,90,100,clockwise,Google Testパス用のサンプル

--- a/datafiles/LineTraceLeft.csv
+++ b/datafiles/LineTraceLeft.csv
@@ -1,0 +1,1 @@
+AR,90,100,clockwise,Google Testパス用のサンプル

--- a/datafiles/LineTraceRight.csv
+++ b/datafiles/LineTraceRight.csv
@@ -1,0 +1,1 @@
+AR,90,100,clockwise,Google Testパス用のサンプル

--- a/datafiles/SmartCarryLeft.csv
+++ b/datafiles/SmartCarryLeft.csv
@@ -1,0 +1,1 @@
+AR,90,100,clockwise,Google Testパス用のサンプル

--- a/datafiles/SmartCarryRight.csv
+++ b/datafiles/SmartCarryRight.csv
@@ -1,0 +1,1 @@
+AR,90,100,clockwise,Google Testパス用のサンプル

--- a/module/AreaMaster.h
+++ b/module/AreaMaster.h
@@ -13,11 +13,8 @@
 #include "MotionParser.h"
 #include "Logger.h"
 
-// エリア攻略のクラスが未定義のため、仮のエリアを指定
-enum Area { AreaMaster };
-
 // エリア名を持つ列挙型変数（LineTrace = 0, DoubleLoop = 1, DebrisRemoval = 2, SmartCarry = 3）
-// enum Area { LineTrace, DoubleLoop, DebrisRemoval, SmartCarry };
+enum Area { LineTrace, DoubleLoop, DebrisRemoval, SmartCarry };
 
 class AreaMaster {
  public:
@@ -44,12 +41,8 @@ class AreaMaster {
   // 各エリアのコマンドファイルベースパス
   const char* basePath = "etrobocon2024/datafiles/";
 
-  // コマンドファイル名
-  const char* commandFileNames[1] = { "AreaMaster" };
-
-  // TODO:今後切り替えるコマンドファイル名
-  // // コマンドファイル名（各エリア名）
-  // const char* commandFileNames[4] = { "LineTrace", "DoubleLoop", "DebrisRemoval", "SmartCarry" };
+  // コマンドファイル名（各エリア名）
+  const char* commandFileNames[4] = { "LineTrace", "DoubleLoop", "DebrisRemoval", "SmartCarry" };
 };
 
 #endif

--- a/test/AreaMasterTest.cpp
+++ b/test/AreaMasterTest.cpp
@@ -14,9 +14,9 @@ using namespace std;
 namespace etrobocon2024_test {
 
   // 左コースで指定動作を行う場合のテスト
-  TEST(AreaMasterTest, runLeftCourse)
+  TEST(AreaMasterTest, runLineTraceLeft)
   {
-    Area area = Area::AreaMaster;
+    Area area = Area::LineTrace;
     bool isLeftCourse = true;
     bool isLeftEdge = isLeftCourse;
     int targetBrightness = 45;
@@ -37,9 +37,135 @@ namespace etrobocon2024_test {
   }
 
   // 右コースで指定動作を行う場合のテスト
-  TEST(AreaMasterTest, runRightCourse)
+  TEST(AreaMasterTest, runLineTraceRight)
   {
-    Area area = Area::AreaMaster;
+    Area area = Area::LineTrace;
+    bool isLeftCourse = false;
+    bool isLeftEdge = isLeftCourse;
+    int targetBrightness = 45;
+
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    class AreaMaster areaMaster(area, isLeftCourse, isLeftEdge, targetBrightness);
+    areaMaster.run();
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // find("str")はstrが見つからない場合string::nposを返す
+    bool actual = output.find("Warning") == string::npos && output.find("Error") == string::npos;
+    printf("%s", output.c_str());
+    EXPECT_TRUE(actual);  // WarningやErrorが出ていないかテスト
+  }
+
+  // 左コースで指定動作を行う場合のテスト
+  TEST(AreaMasterTest, runDoubleLoopLeft)
+  {
+    Area area = Area::DoubleLoop;
+    bool isLeftCourse = true;
+    bool isLeftEdge = isLeftCourse;
+    int targetBrightness = 45;
+
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    class AreaMaster areaMaster(area, isLeftCourse, isLeftEdge, targetBrightness);
+    areaMaster.run();
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // find("str")はstrが見つからない場合string::nposを返す
+    bool actual = output.find("Warning") == string::npos && output.find("Error") == string::npos;
+    printf("%s", output.c_str());
+    EXPECT_TRUE(actual);  // WarningやErrorが出ていないかテスト
+    // WarningやErrorが出ていた場合にoutputを出力する
+    if(!actual) {
+      EXPECT_EQ(output, "");
+    }
+  }
+
+  // 右コースで指定動作を行う場合のテスト
+  TEST(AreaMasterTest, runDoubleLoopRight)
+  {
+    Area area = Area::DoubleLoop;
+    bool isLeftCourse = false;
+    bool isLeftEdge = isLeftCourse;
+    int targetBrightness = 45;
+
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    class AreaMaster areaMaster(area, isLeftCourse, isLeftEdge, targetBrightness);
+    areaMaster.run();
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // find("str")はstrが見つからない場合string::nposを返す
+    bool actual = output.find("Warning") == string::npos && output.find("Error") == string::npos;
+    printf("%s", output.c_str());
+    EXPECT_TRUE(actual);  // WarningやErrorが出ていないかテスト
+  }
+
+  // 左コースで指定動作を行う場合のテスト
+  TEST(AreaMasterTest, runDebrisRemovalLeft)
+  {
+    Area area = Area::DebrisRemoval;
+    bool isLeftCourse = true;
+    bool isLeftEdge = isLeftCourse;
+    int targetBrightness = 45;
+
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    class AreaMaster areaMaster(area, isLeftCourse, isLeftEdge, targetBrightness);
+    areaMaster.run();
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // find("str")はstrが見つからない場合string::nposを返す
+    bool actual = output.find("Warning") == string::npos && output.find("Error") == string::npos;
+    printf("%s", output.c_str());
+    EXPECT_TRUE(actual);  // WarningやErrorが出ていないかテスト
+    // WarningやErrorが出ていた場合にoutputを出力する
+    if(!actual) {
+      EXPECT_EQ(output, "");
+    }
+  }
+
+  // 右コースで指定動作を行う場合のテスト
+  TEST(AreaMasterTest, runDebrisRemovalRight)
+  {
+    Area area = Area::DebrisRemoval;
+    bool isLeftCourse = false;
+    bool isLeftEdge = isLeftCourse;
+    int targetBrightness = 45;
+
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    class AreaMaster areaMaster(area, isLeftCourse, isLeftEdge, targetBrightness);
+    areaMaster.run();
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // find("str")はstrが見つからない場合string::nposを返す
+    bool actual = output.find("Warning") == string::npos && output.find("Error") == string::npos;
+    printf("%s", output.c_str());
+    EXPECT_TRUE(actual);  // WarningやErrorが出ていないかテスト
+  }
+
+  // 左コースで指定動作を行う場合のテスト
+  TEST(AreaMasterTest, runSmartCarryLeft)
+  {
+    Area area = Area::SmartCarry;
+    bool isLeftCourse = true;
+    bool isLeftEdge = isLeftCourse;
+    int targetBrightness = 45;
+
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    class AreaMaster areaMaster(area, isLeftCourse, isLeftEdge, targetBrightness);
+    areaMaster.run();
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // find("str")はstrが見つからない場合string::nposを返す
+    bool actual = output.find("Warning") == string::npos && output.find("Error") == string::npos;
+    printf("%s", output.c_str());
+    EXPECT_TRUE(actual);  // WarningやErrorが出ていないかテスト
+    // WarningやErrorが出ていた場合にoutputを出力する
+    if(!actual) {
+      EXPECT_EQ(output, "");
+    }
+  }
+
+  // 右コースで指定動作を行う場合のテスト
+  TEST(AreaMasterTest, runSmartCarryRight)
+  {
+    Area area = Area::SmartCarry;
     bool isLeftCourse = false;
     bool isLeftEdge = isLeftCourse;
     int targetBrightness = 45;

--- a/test/ColorStraightTest.cpp
+++ b/test/ColorStraightTest.cpp
@@ -9,7 +9,7 @@
 
 using namespace std;
 
-namespace etrobocon2023_test {
+namespace etrobocon2024_test {
 
   // 最初の色取得で指定色を取得するテストケース
   TEST(ColorStraightTest, runToGetFirst)
@@ -185,4 +185,4 @@ namespace etrobocon2023_test {
     EXPECT_EQ(expected, actual);              // 直進前後で走行距離に変化はない
   }
 
-}  // namespace etrobocon2023_test
+}  // namespace etrobocon2024_test


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
各攻略エリアの定義を AreaMaster.cpp ファイルで定義。
追加して定義した攻略エリアについてのGoogleTestをパスするよう、サンプルのCSVファイルを追加。
また、ColorStraightTest の名前空間が2023_testになっていたため、2024_testに修正。
