### PR TITLE
#close KLI-155 モータ停止コマンドの実装

### DIFF
--- a/module/EtRobocon2024.cpp
+++ b/module/EtRobocon2024.cpp
@@ -53,7 +53,7 @@ void EtRobocon2024::start()
   bool isLeftEdge = true;
   Calibrator calibrator;
 
-    // キャリブレーションする
+  // キャリブレーションする
   calibrator.run();
   isLeftCourse = calibrator.getIsLeftCourse();
   // isLeftCourse = true;
@@ -61,16 +61,16 @@ void EtRobocon2024::start()
   int targetBrightness = calibrator.getTargetBrightness();
 
   // int targetBrightness = 50;
- // 各エリアを走行する
+  // 各エリアを走行する
   // 走行状態をwait(開始合図待ち)に変更
-  setstate("wait");
+  // setstate("wait");
   // 合図を送るまで待機する
   calibrator.waitForStart();
 
   AreaMaster LineTraceAreaMaster(Area::LineTrace, isLeftCourse, isLeftEdge, targetBrightness);
   AreaMaster doubleLoopAreaMaster(Area::DoubleLoop, isLeftCourse, isLeftEdge, targetBrightness);
-  AreaMaster DebrisRemovalAreaMaster(Area::DebrisRemoval, isLeftCourse, isLeftEdge, targetBrightness);
-  
+  AreaMaster DebrisRemovalAreaMaster(Area::DebrisRemoval, isLeftCourse, isLeftEdge,
+                                     targetBrightness);
 
   // LAPゲートを通過する
   LineTraceAreaMaster.run();

--- a/module/Motion/LineTracing.cpp
+++ b/module/Motion/LineTracing.cpp
@@ -57,6 +57,7 @@ void LineTracing::run()
     // 10ミリ秒待機
     timer.sleep(10);
   }
+
   // モータの停止
   // controller.stopWheelsMotor();
 }

--- a/module/Motion/LineTracing.cpp
+++ b/module/Motion/LineTracing.cpp
@@ -57,6 +57,8 @@ void LineTracing::run()
     // 10ミリ秒待機
     timer.sleep(10);
   }
+  // モータの停止
+  // controller.stopWheelsMotor();
 }
 
 void LineTracing::logRunning()

--- a/module/Motion/LineTracing.cpp
+++ b/module/Motion/LineTracing.cpp
@@ -57,9 +57,6 @@ void LineTracing::run()
     // 10ミリ秒待機
     timer.sleep(10);
   }
-
-  // モータの停止
-  controller.stopWheelsMotor();
 }
 
 void LineTracing::logRunning()

--- a/module/Motion/ResetWheelsMotorPwm.cpp
+++ b/module/Motion/ResetWheelsMotorPwm.cpp
@@ -1,0 +1,19 @@
+/**
+ * @file   ResetWheelsMotorPwm.cpp
+ * @brief  両輪モーターリセット&停止
+ * @author YourName
+ */
+
+#include "ResetWheelsMotorPwm.h"
+
+ResetWheelsMotorPwm::ResetWheelsMotorPwm() {}
+
+void ResetWheelsMotorPwm::run()
+{
+  controller.resetWheelsMotorPwm();
+}
+
+void ResetWheelsMotorPwm::logRunning()
+{
+  logger.log("Run ResetWheelsMotorPwm");
+}

--- a/module/Motion/ResetWheelsMotorPwm.cpp
+++ b/module/Motion/ResetWheelsMotorPwm.cpp
@@ -1,7 +1,7 @@
 /**
  * @file   ResetWheelsMotorPwm.cpp
  * @brief  両輪モーターリセット&停止
- * @author YourName
+ * @author Negimarge
  */
 
 #include "ResetWheelsMotorPwm.h"

--- a/module/Motion/ResetWheelsMotorPwm.h
+++ b/module/Motion/ResetWheelsMotorPwm.h
@@ -1,0 +1,34 @@
+/**
+ * @file   ResetWheelsMotorPwm.h
+ * @brief  両輪モーターリセット&停止
+ * @author Negimarge
+ */
+
+#ifndef RESET_WHEELS_MOTOR_PWM_H
+#define RESET_WHEELS_MOTOR_PWM_H
+
+#include "Motion.h"
+#include "Controller.h"
+
+class ResetWheelsMotorPwm : public Motion {
+ public:
+  /**
+   * コンストラクタ
+   */
+  ResetWheelsMotorPwm();
+
+  /**
+   * @brief 両輪モーターをリセットする
+   */
+  void run();
+
+  /**
+   * @brief 実行のログを取る
+   */
+  void logRunning();
+
+ private:
+  Controller controller;
+};
+
+#endif

--- a/module/Motion/Rotation.cpp
+++ b/module/Motion/Rotation.cpp
@@ -47,5 +47,5 @@ void Rotation::run()
   }
 
   // モータの停止
-  controller.stopWheelsMotor();
+  // controller.stopWheelsMotor();
 }

--- a/module/Motion/StopWheelsMotor.cpp
+++ b/module/Motion/StopWheelsMotor.cpp
@@ -1,0 +1,19 @@
+/**
+ * @file   StopWheelsMotor.cpp
+ * @brief  両輪モーター停止
+ * @author YourName
+ */
+
+#include "StopWheelsMotor.h"
+
+StopWheelsMotor::StopWheelsMotor() {}
+
+void StopWheelsMotor::run()
+{
+  controller.stopWheelsMotor();
+}
+
+void StopWheelsMotor::logRunning()
+{
+  logger.log("Run StopWheelsMotor");
+}

--- a/module/Motion/StopWheelsMotor.cpp
+++ b/module/Motion/StopWheelsMotor.cpp
@@ -1,7 +1,7 @@
 /**
  * @file   StopWheelsMotor.cpp
  * @brief  両輪モーター停止
- * @author YourName
+ * @author Negimarge
  */
 
 #include "StopWheelsMotor.h"

--- a/module/Motion/StopWheelsMotor.h
+++ b/module/Motion/StopWheelsMotor.h
@@ -1,0 +1,34 @@
+/**
+ * @file   StopWheelsMotor.h
+ * @brief  両輪モーター停止
+ * @author Negimarge
+ */
+
+#ifndef STOP_WHEELS_MOTOR_H
+#define STOP_WHEELS_MOTOR_H
+
+#include "Motion.h"
+#include "Controller.h"
+
+class StopWheelsMotor : public Motion {
+ public:
+  /**
+   * コンストラクタ
+   */
+  StopWheelsMotor();
+
+  /**
+   * @brief 両輪モーターを停止する
+   */
+  void run();
+
+  /**
+   * @brief 実行のログを取る
+   */
+  void logRunning();
+
+ private:
+  Controller controller;
+};
+
+#endif

--- a/module/Motion/Straight.cpp
+++ b/module/Motion/Straight.cpp
@@ -38,7 +38,7 @@ void Straight::run()
     timer.sleep(10);
   }
   // モータの停止
-  controller.stopWheelsMotor();
+  // controller.stopWheelsMotor();
 }
 
 bool Straight::isMetPreCondition()

--- a/module/MotionParser.cpp
+++ b/module/MotionParser.cpp
@@ -91,6 +91,18 @@ vector<Motion*> MotionParser::createMotions(const char* commandFilePath, int tar
       motionList.push_back(sl);  // 動作リストに追加
     }
 
+    else if(command == COMMAND::RM) {  // 両輪モーターリセット&停止の生成
+      // モーターのリセット
+      ResetWheelsMotorPwm* rm = new ResetWheelsMotorPwm();  // モーターのリセット
+
+      motionList.push_back(rm);  // 動作リストに追加
+    }
+
+    else if(command == COMMAND::SM) {               // 両輪モーター停止の生成
+      StopWheelsMotor* sm = new StopWheelsMotor();  // モーターの停止
+
+      motionList.push_back(sm);  // 動作リストに追加
+    }
     // TODO: 後で作成する
 
     //    }else if(command == COMMAND::DT) {  // 距離指定旋回動作の生成
@@ -152,6 +164,10 @@ COMMAND MotionParser::convertCommand(char* str)
     return COMMAND::AD;
   } else if(strcmp(str, "XR") == 0) {  // 文字列がXRの場合
     return COMMAND::XR;
+  } else if(strcmp(str, "RM") == 0) {  // 文字列がRMの場合
+    return COMMAND::RM;
+  } else if(strcmp(str, "SM") == 0) {  // 文字列がSMの場合
+    return COMMAND::SM;
   } else {  // 想定していない文字列が来た場合
     return COMMAND::NONE;
   }

--- a/module/MotionParser.h
+++ b/module/MotionParser.h
@@ -20,6 +20,8 @@
 #include "DistanceStraight.h"
 #include "EdgeChanging.h"
 #include "Sleeping.h"
+#include "StopWheelsMotor.h"
+#include "ResetWheelsMotorPwm.h"
 
 #define READ_BUF_SIZE 256  // コマンドのパラメータ読み込み用の領域
 
@@ -35,6 +37,8 @@ enum class COMMAND {
   AU,  // アームを上げる
   AD,  // アームを下げる
   XR,  // 角度補正回頭
+  RM,  // 両輪モーターリセット&停止
+  SM,  // 両輪モーター停止
   NONE
 };
 


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
両輪のpwm値を0にしてダミーをリセットするResetWheelsMotorPwm.cppとResetWheelsMotorPwm.hを追加
両輪のpwm値を0にしてダミーをストップするResetWheelsMotorPwm.cppとResetWheelsMotorPwm.hを追加
Straight.cpp, Rotation.cpp, LineTracing.cppから controller.stopWheelsMotor();をコメントアウト

# 動作テスト
テストいじらなくても通った
呼び出しだけの関数より、テストは作成していない
