### PR TITLE
close #ticket-KLI-171 試走会2で使用するカメラ撮影動作実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 HOST = $(shell hostname)
-SERVER_URL = "無線通信デバイスのサーバURL"
+SERVER_URL = サーバーのURL
 make = make --no-print-directory
 
 # 使い方
@@ -49,7 +49,7 @@ rebuild:
 
 # 無線通信デバイスのサーバーに画像をアップロードする
 upload:
-	curl -X POST -F "file=@$(FILE_PATH)" $(SERVER_URL)/upload
+	curl -X POST -F "file=@"$(FILE_PATH)"" $(SERVER_URL)/images
 
 # 実機の場合、走行を開始する 
 start:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 HOST = $(shell hostname)
+SERVER_URL = "無線通信デバイスのサーバURL"
 make = make --no-print-directory
 
 # 使い方
@@ -8,8 +9,8 @@ help:
 	@echo " $$ make build"
 	@echo ビルドファイルを消してからビルドする
 	@echo " $$ make rebuild"
-	@echo 走行状態を提供するサーバを起動する
-	@echo " $$ make server"
+	@echo 無線通信デバイスのサーバーに画像をアップロードする
+	@echo " $$ make upload"
 	@echo 走行を開始する\(実機限定\)
 	@echo " $$ make start"
 	@echo 中断したmakeプロセスをkillする
@@ -46,10 +47,9 @@ rebuild:
 	rm -rf build
 	@${make} build
 
-# 走行状態を提供するWebサーバを起動する
-.PHONY: server
-server:
-	cd $(MAKEFILE_PATH)/server && python3 flask_server.py
+# 無線通信デバイスのサーバーに画像をアップロードする
+upload:
+	curl -X POST -F "file=@$(FILE_PATH)" $(SERVER_URL)/upload
 
 # 実機の場合、走行を開始する 
 start:

--- a/front_camera/Makefile
+++ b/front_camera/Makefile
@@ -11,7 +11,7 @@ help:
 
 ## 画像取得関連 ##
 ifeq ($(SAVE_NAME),)
-    SAVE_NAME = Fig_1.png # デフォルト値
+    SAVE_NAME = Fig.jpeg # デフォルト値
 endif
 image:
 	@${make} kill

--- a/front_camera/front_camera/camera_interface.py
+++ b/front_camera/front_camera/camera_interface.py
@@ -5,6 +5,7 @@
 from picamera2 import Picamera2, MappedArray
 from datetime import datetime
 from typing import Tuple, Union
+from PIL import Image
 import cv2
 import numpy as np
 import os
@@ -54,7 +55,10 @@ class CameraInterface:
             save_path (int): 画像の保存先パス(拡張子込み)
         """
         img = self.capture_image()
-        cv2.imwrite(save_path, img)
+        img = np.array(img)
+        img = img[:, :, ::-1]
+        im = Image.fromarray(img)
+        im.save(save_path)
 
     def capture_image_cv2(self, save_path):
         ret, frame = self.cap.read()

--- a/module/Motion/CameraAction.cpp
+++ b/module/Motion/CameraAction.cpp
@@ -1,0 +1,47 @@
+/**
+ * @file   CameraAction.cpp
+ * @brief  カメラ撮影動作
+ * @author bizyutyu
+ */
+
+#include "CameraAction.h"
+
+using namespace std;
+
+// countShootFigureの初期化
+int CameraAction::countShootFigure = 0;
+
+CameraAction::CameraAction(Subject _subject)
+  : subject(_subject){};
+
+void CameraAction::run()
+{
+  // フロントカメラで画像を取得する
+  // 画像のファイル名と撮影コマンドを指定
+  char imageName[20];         // 画像のファイル名
+  char makeImageCommand[10];  // 撮影に用いるmakeコマンド名
+  if(subject == CameraAction::Subject::FIGURE) {
+    countShootFigure++;
+    sprintf(imageName, "Fig_%d.jpeg", countShootFigure);
+    sprintf(makeImageCommand, "image");
+  } else if(subject == CameraAction::Subject::PLARAIL) {
+    sprintf(imageName, "Pla.jpeg");
+    sprintf(makeImageCommand, "image");
+  }
+
+  // 撮影に際してディレクトリ移動も行う
+  char cmd[256];
+  snprintf(cmd, 256, "cd etrobocon2023/front_camera && make %s SAVE_NAME=%s && cd ../..",
+           makeImageCommand, imageName);
+  system(cmd);
+
+  printf("%s\n", cmd);
+}
+
+void CameraAction::logRunning()
+{
+  char buf[LARGE_BUF_SIZE];  // log用にメッセージを一時保持する領域
+
+  snprintf(buf, LARGE_BUF_SIZE, "Run CameraAction ()");
+  logger.log(buf);
+}

--- a/module/Motion/CameraAction.cpp
+++ b/module/Motion/CameraAction.cpp
@@ -33,8 +33,17 @@ void CameraAction::run()
   snprintf(cmd, 256, "cd etrobocon2024/front_camera && make %s SAVE_NAME=%s && cd ../..",
            makeImageCommand, imageName);
   system(cmd);
-
   printf("%s\n", cmd);
+
+  // 画像アップロードに際してディレクトリ移動も行う
+  char uploadImageName[20] = "Fig_3.jpeg";  // アップロードするミニフィグの画像を指定
+  if(imageName == uploadImageName || imageName == "Pla.jpeg") {
+    snprintf(cmd, 256,
+             "cd etrobocon2024 && make upload FILE_PATH=front_camera/image_data/%s && cd ..",
+             imageName);
+    system(cmd);
+    printf("%s\n", cmd);
+  }
 }
 
 void CameraAction::logRunning()

--- a/module/Motion/CameraAction.cpp
+++ b/module/Motion/CameraAction.cpp
@@ -37,7 +37,7 @@ void CameraAction::run()
 
   // 画像アップロードに際してディレクトリ移動も行う
   char uploadImageName[20] = "Fig_3.jpeg";  // アップロードするミニフィグの画像を指定
-  if(imageName == uploadImageName || imageName == "Pla.jpeg") {
+  if(strcmp(imageName, uploadImageName) == 0 || strcmp(imageName, "Pla.jpeg") == 0) {
     snprintf(cmd, 256,
              "cd etrobocon2024 && make upload FILE_PATH=front_camera/image_data/%s && cd ..",
              imageName);

--- a/module/Motion/CameraAction.cpp
+++ b/module/Motion/CameraAction.cpp
@@ -11,8 +11,7 @@ using namespace std;
 // countShootFigureの初期化
 int CameraAction::countShootFigure = 0;
 
-CameraAction::CameraAction(Subject _subject)
-  : subject(_subject){};
+CameraAction::CameraAction(Subject _subject) : subject(_subject){};
 
 void CameraAction::run()
 {

--- a/module/Motion/CameraAction.cpp
+++ b/module/Motion/CameraAction.cpp
@@ -31,7 +31,7 @@ void CameraAction::run()
 
   // 撮影に際してディレクトリ移動も行う
   char cmd[256];
-  snprintf(cmd, 256, "cd etrobocon2023/front_camera && make %s SAVE_NAME=%s && cd ../..",
+  snprintf(cmd, 256, "cd etrobocon2024/front_camera && make %s SAVE_NAME=%s && cd ../..",
            makeImageCommand, imageName);
   system(cmd);
 

--- a/module/Motion/CameraAction.h
+++ b/module/Motion/CameraAction.h
@@ -1,0 +1,40 @@
+/**
+ * @file   CameraAction.h
+ * @brief  カメラ撮影動作
+ * @author bizyutyu
+ */
+
+#ifndef CAMERAACTION_H
+#define CAMERAACTION_H
+
+#include "CompositeMotion.h"
+
+class CameraAction : public CompositeMotion {
+ public:
+  /**
+   * 撮影対象判別の為の型
+   * @param subject FIGURE:ミニフィグ PLARAIL:プラレール・背景
+   */
+  enum class Subject { FIGURE, PLARAIL, UNDEFINED };
+
+  /**
+   * コンストラクタ
+   * @param _subject 撮影対象　FIGURE:ミニフィグ PLARAIL:プラレール・背景
+   */
+  CameraAction(Subject _subject);
+
+  /**
+   * @brief 撮影動作を行う
+   */
+  void run() override;
+
+  /**
+   * @brief 実行のログを取る
+   */
+  void logRunning() override;
+
+ private:
+  Subject subject;  // 撮影対象(FIGURE:ミニフィグ, PLARAIL:プラレール・背景)
+  static int countShootFigure;  // ミニフィグの撮影回数をカウント
+};
+#endif

--- a/module/Motion/CompositeMotion.cpp
+++ b/module/Motion/CompositeMotion.cpp
@@ -1,0 +1,9 @@
+/**
+ * @file   CompositeMotion.cpp
+ * @brief  合成動作クラス
+ * @author bizyutyu
+ */
+
+#include "CompositeMotion.h"
+
+CompositeMotion::CompositeMotion(){};

--- a/module/Motion/CompositeMotion.h
+++ b/module/Motion/CompositeMotion.h
@@ -1,0 +1,31 @@
+/**
+ * @file   CompositeMotion.h
+ * @brief  合成動作クラス
+ * @author bizyutyu
+ */
+
+#ifndef COMPOSITEMOTION_H
+#define COMPOSITEMOTION_H
+
+#include "Motion.h"
+
+class CompositeMotion : public Motion {
+ public:
+  /**
+   * コンストラクタ
+   */
+  CompositeMotion();
+
+  /**
+   * @brief 合成動作を行う
+   * @note オーバーライド必須
+   */
+  virtual void run() = 0;
+
+  /**
+   * @brief 実行のログを取る
+   * @note オーバーライド必須
+   */
+  virtual void logRunning() = 0;
+};
+#endif

--- a/module/MotionParser.cpp
+++ b/module/MotionParser.cpp
@@ -1,7 +1,7 @@
 /**
  * @file   MotionParser.cpp
  * @brief  動作コマンドファイルを解析するクラス
- * @author keiya121
+ * @author keiya121 bizyutyu
  */
 
 #include "MotionParser.h"
@@ -109,7 +109,12 @@ vector<Motion*> MotionParser::createMotions(const char* commandFilePath, int tar
     else if(command == COMMAND::SM) {               // 両輪モーター停止の生成
       StopWheelsMotor* sm = new StopWheelsMotor();  // モーターの停止
 
-      motionList.push_back(sm);  // 動作リストに追加
+      motionList.push_back(sm);          // 動作リストに追加
+    } else if(command == COMMAND::CA) {  // カメラ撮影動作の生成
+      CameraAction* ca = new CameraAction(
+          convertSubject(params[1]));  // フラグ確認を行うかの判断に用いる撮影対象
+
+      motionList.push_back(ca);  // 動作リストに追加
     }
     // TODO: 後で作成する
 
@@ -178,6 +183,8 @@ COMMAND MotionParser::convertCommand(char* str)
     return COMMAND::RM;
   } else if(strcmp(str, "SM") == 0) {  // 文字列がSMの場合
     return COMMAND::SM;
+  } else if(strcmp(str, "CA") == 0) {  // 文字列がCAの場合
+    return COMMAND::CA;
   } else {  // 想定していない文字列が来た場合
     return COMMAND::NONE;
   }
@@ -210,5 +217,22 @@ bool MotionParser::convertBool(char* command, char* stringParameter)
       logger.logWarning("Parameter before conversion must be 'left' or 'right'");
       return true;
     }
+  }
+}
+
+CameraAction::Subject MotionParser::convertSubject(char* stringParameter)
+{
+  Logger logger;
+
+  // 末尾の改行を削除
+  char* param = StringOperator::removeEOL(stringParameter);
+
+  if(strcmp(param, "FIG") == 0) {  // パラメータがFIGの場合
+    return CameraAction::Subject::FIGURE;
+  } else if(strcmp(param, "PLA") == 0) {  // パラメータがPLAの場合
+    return CameraAction::Subject::PLARAIL;
+  } else {  // 想定していないパラメータが来た場合
+    logger.logWarning("Parameter before conversion must be 'FIG' or 'PLA'");
+    return CameraAction::Subject::UNDEFINED;
   }
 }

--- a/module/MotionParser.h
+++ b/module/MotionParser.h
@@ -1,7 +1,7 @@
 /**
  * @file   MotionParser.h
  * @brief  動作コマンドファイルを解析するクラス
- * @author keiya121
+ * @author keiya121 bizyutyu
  */
 
 #ifndef MOTION_PARSER_H
@@ -23,6 +23,7 @@
 #include "Sleeping.h"
 #include "StopWheelsMotor.h"
 #include "ResetWheelsMotorPwm.h"
+#include "CameraAction.h"
 
 #define READ_BUF_SIZE 256  // コマンドのパラメータ読み込み用の領域
 
@@ -41,6 +42,7 @@ enum class COMMAND {
   XR,  // 角度補正回頭
   RM,  // 両輪モーターリセット&停止
   SM,  // 両輪モーター停止
+  CA,  // カメラ撮影動作
   NONE
 };
 
@@ -73,6 +75,13 @@ class MotionParser {
    * @return bool値
    */
   static bool convertBool(char* command, char* stringParameter);
+
+  /**
+   * @brief 文字列をSubject型に変換する
+   * @param stringParameter 文字列のパラメータ
+   * @return Subject値
+   */
+  static CameraAction::Subject convertSubject(char* stringParameter);
 };
 
 #endif


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- カメラ撮影動作の為の、ファイルとコマンドの実装。
- カメラ撮影後の画像保存に用いていたライブラリと関連コードを変更。

# コマンド説明
- コマンドは```CA```で、引数は撮影対象。
   - 撮影対象がミニフィグの場合は```CA,FIG```、プラレール・背景の場合は```CA,PLA```と指定すれば良い。
   - FIGを指定した撮影では、```make start```を実行すると"Fig_0.jpeg"という名前から始まり"Fig_1jpeg","Fig_2.jpeg"と、撮影を重ねるたびに添字?が1増えていく。

# 動作テスト
実機において、コマンドにより画像を取得し、Fig_1.jpeg, Fig_2.jpeg, Fig_3.jpeg, Fig_4.jpeg, Pla.jpegという名前の画像として保存できることを確認しました。

## 添付資料
