### PR TITLE
close KLI-212 タイムアウトの原因調査・改善

### DIFF
--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -107,6 +107,7 @@ bool Calibrator::waitForStart()
 {
   char buf[SMALL_BUF_SIZE];  // log用にメッセージを一時保持する領域
   Logger logger;
+  Measurer measurer; // measurerの再インスタンス化
   constexpr int startDistance = 5;  // 手などでスタート合図を出す距離[cm]
   int count = 0;
 
@@ -116,16 +117,17 @@ bool Calibrator::waitForStart()
   logger.log(buf);
 
   // startDistance以内の距離に物体がない間待機する
-  while(measurer.getForwardDistance() > startDistance && !measurer.getLeftButton() && count < 6000) {
-    timer.sleep();  // 10ミリ秒スリープ
+  while(measurer.getForwardDistance() > startDistance && !measurer.getLeftButton() && count < 600) {
+    timer.sleep(100);  // 100ミリ秒スリープ
     count++;
-    if(count % 1000 == 0) {
-      snprintf(buf, SMALL_BUF_SIZE, "count: %d", count);
+    if(count % 50 == 0) {
+      snprintf(buf, SMALL_BUF_SIZE, "count: %d\nbrightness: %d\nforwardDistance: %d", 
+      count, measurer.getBrightness(), measurer.getForwardDistance());
       logger.log(buf);
     }
   }
 
-  return count < 6000;
+  return count < 600;
 }
 
 bool Calibrator::getIsLeftCourse()

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -116,12 +116,16 @@ bool Calibrator::waitForStart()
   logger.log(buf);
 
   // startDistance以内の距離に物体がない間待機する
-  while((measurer.getForwardDistance() > startDistance) && (count < 60000)) {
+  while((measurer.getForwardDistance() > startDistance) && (count < 6000)) {
     timer.sleep();  // 10ミリ秒スリープ
     count++;
+    if(count % 1000 == 0) {
+      snprintf(buf, SMALL_BUF_SIZE, "count: %d", count);
+      logger.log(buf);
+    }
   }
 
-  return count < 60000;
+  return count < 6000;
 }
 
 bool Calibrator::getIsLeftCourse()

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -6,10 +6,7 @@
 
 #include "Calibrator.h"
 
-Calibrator::Calibrator() : isLeftCourse(true), targetBrightness(50)
-{
-  delete measurer;
-}
+Calibrator::Calibrator() : isLeftCourse(true), targetBrightness(50) {}
 
 void Calibrator::run()
 {

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -28,17 +28,18 @@ void Calibrator::selectAndSetCourse()
   char buf[SMALL_BUF_SIZE];  // log用にメッセージを一時保持する領域
   Logger logger;
   bool _isLeftCourse = true;
+  Measurer* measurer = new Measurer();
 
   logger.log("Select a Course");
   logger.log(">> Set Left Course");
   // 右ボタンが押されたら確定する
-  while(!measurer.getRightButton()) {
-    if(measurer.getLeftButton() && !_isLeftCourse) {
+  while(!measurer->getRightButton()) {
+    if(measurer->getLeftButton() && !_isLeftCourse) {
       // 左ボタンが押されたときRコースがセットされていれば、Lコースをセットする
       _isLeftCourse = true;
       logger.log(">> Set Left Course");
       timer.sleep(500);  // 500ミリ秒スリープ
-    } else if(measurer.getLeftButton() && _isLeftCourse) {
+    } else if(measurer->getLeftButton() && _isLeftCourse) {
       // 左ボタンが押されたときLコースがセットされていれば、Rコースをセットする
       _isLeftCourse = false;
       logger.log(">> Set Right Course");
@@ -54,6 +55,7 @@ void Calibrator::selectAndSetCourse()
   logger.logHighlight(buf);
 
   timer.sleep(1000);  // 1秒スリープ
+  delete measurer;
 }
 
 void Calibrator::measureAndSetTargetBrightness()
@@ -63,19 +65,20 @@ void Calibrator::measureAndSetTargetBrightness()
   int whiteBrightness = -1;
   int blackBrightness = -1;
   targetBrightness = -1;
+  Measurer* measurer = new Measurer();
 
   // 黒線上で左ボタンを押して黒の輝度を取得し、右ボタンで決定する
   logger.log("Press the Left Button on the Black");
 
   // 黒
   // 左ボタンで輝度を取得し、右ボタンで黒の輝度を決定する
-  while(blackBrightness < 0 || !measurer.getRightButton()) {
+  while(blackBrightness < 0 || !measurer->getRightButton()) {
     // 左ボタンが押されるまで待機
-    while(blackBrightness < 0 && !measurer.getLeftButton()) {
+    while(blackBrightness < 0 && !measurer->getLeftButton()) {
       timer.sleep();  // 10ミリ秒スリープ
     }
     // 輝度取得
-    blackBrightness = measurer.getBrightness();
+    blackBrightness = measurer->getBrightness();
     snprintf(buf, SMALL_BUF_SIZE, ">> Black Brightness Value is %d", blackBrightness);
     logger.log(buf);
     timer.sleep();  // 10ミリ秒スリープ
@@ -86,13 +89,13 @@ void Calibrator::measureAndSetTargetBrightness()
 
   // 白
   // 左ボタンで輝度を取得し、右ボタンで白の輝度を決定する
-  while(whiteBrightness < 0 || !measurer.getRightButton()) {
+  while(whiteBrightness < 0 || !measurer->getRightButton()) {
     // 左ボタンが押されるまで待機
-    while(whiteBrightness < 0 && !measurer.getLeftButton()) {
+    while(whiteBrightness < 0 && !measurer->getLeftButton()) {
       timer.sleep();  // 10ミリ秒スリープ
     }
     // 輝度取得
-    whiteBrightness = measurer.getBrightness();
+    whiteBrightness = measurer->getBrightness();
     snprintf(buf, SMALL_BUF_SIZE, ">> White Brightness Value is %d", whiteBrightness);
     logger.log(buf);
     timer.sleep();  // 10ミリ秒スリープ
@@ -101,15 +104,19 @@ void Calibrator::measureAndSetTargetBrightness()
   targetBrightness = (whiteBrightness + blackBrightness) / 2;
   snprintf(buf, SMALL_BUF_SIZE, ">> Target Brightness Value is %d", targetBrightness);
   logger.log(buf);
+
+  delete measurer;
 }
 
 bool Calibrator::waitForStart()
 {
   char buf[SMALL_BUF_SIZE];  // log用にメッセージを一時保持する領域
   Logger logger;
-  Measurer measurer; // measurerの再インスタンス化
   constexpr int startDistance = 5;  // 手などでスタート合図を出す距離[cm]
   int count = 0;
+
+  // Measurerの再インスタンス化
+  Measurer* measurer = new Measurer();
 
   logger.log("On standby.\n");
   snprintf(buf, SMALL_BUF_SIZE, "On standby.\n\nSignal within %dcm from Sonar Sensor.",
@@ -117,16 +124,18 @@ bool Calibrator::waitForStart()
   logger.log(buf);
 
   // startDistance以内の距離に物体がない間待機する
-  while(measurer.getForwardDistance() > startDistance && !measurer.getLeftButton() && count < 600) {
+  while(measurer->getForwardDistance() > startDistance && !measurer->getLeftButton() && count < 600) {
     timer.sleep(100);  // 100ミリ秒スリープ
     count++;
+    // 確認用（コマンドラインにセンサの取得値を出力）
     if(count % 50 == 0) {
       snprintf(buf, SMALL_BUF_SIZE, "count: %d\nbrightness: %d\nforwardDistance: %d", 
-      count, measurer.getBrightness(), measurer.getForwardDistance());
+      count, measurer->getBrightness(), measurer->getForwardDistance());
       logger.log(buf);
     }
   }
 
+  delete measurer;
   return count < 600;
 }
 

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -6,7 +6,10 @@
 
 #include "Calibrator.h"
 
-Calibrator::Calibrator() : isLeftCourse(true), targetBrightness(50) {}
+Calibrator::Calibrator() : isLeftCourse(true), targetBrightness(50)
+{
+  delete measurer;
+}
 
 void Calibrator::run()
 {
@@ -28,7 +31,7 @@ void Calibrator::selectAndSetCourse()
   char buf[SMALL_BUF_SIZE];  // log用にメッセージを一時保持する領域
   Logger logger;
   bool _isLeftCourse = true;
-  Measurer* measurer = new Measurer();
+  measurer = new Measurer();
 
   logger.log("Select a Course");
   logger.log(">> Set Left Course");
@@ -65,7 +68,7 @@ void Calibrator::measureAndSetTargetBrightness()
   int whiteBrightness = -1;
   int blackBrightness = -1;
   targetBrightness = -1;
-  Measurer* measurer = new Measurer();
+  measurer = new Measurer();
 
   // 黒線上で左ボタンを押して黒の輝度を取得し、右ボタンで決定する
   logger.log("Press the Left Button on the Black");
@@ -115,7 +118,7 @@ void Calibrator::waitForStart()
   constexpr int startDistance = 5;  // 手などでスタート合図を出す距離[cm]
   int count = 0;
 
-  Measurer* measurer = new Measurer();
+  measurer = new Measurer();
 
   logger.log("On standby.\n");
   snprintf(buf, SMALL_BUF_SIZE, "On standby.\n\nSignal within %dcm from Sonar Sensor.",
@@ -139,7 +142,7 @@ void Calibrator::waitForStart()
     if(count >= 600) {
       // Measurerの再インスタンス化
       delete measurer;
-      Measurer* measurer = new Measurer();
+      measurer = new Measurer();
       count = 0;
       logger.log("\n\nwait again!!\n\n");
     } else {

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -6,7 +6,10 @@
 
 #include "Calibrator.h"
 
-Calibrator::Calibrator() : isLeftCourse(true), targetBrightness(50) {}
+Calibrator::Calibrator() : isLeftCourse(true), targetBrightness(50), measurer(nullptr)
+{
+  delete measurer;
+}
 
 void Calibrator::run()
 {

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -116,7 +116,7 @@ bool Calibrator::waitForStart()
   logger.log(buf);
 
   // startDistance以内の距離に物体がない間待機する
-  while((measurer.getForwardDistance() > startDistance) && (count < 6000)) {
+  while(measurer.getForwardDistance() > startDistance && !measurer.getLeftButton() && count < 6000) {
     timer.sleep();  // 10ミリ秒スリープ
     count++;
     if(count % 1000 == 0) {

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -124,13 +124,14 @@ bool Calibrator::waitForStart()
   logger.log(buf);
 
   // startDistance以内の距離に物体がない間待機する
-  while(measurer->getForwardDistance() > startDistance && !measurer->getLeftButton() && count < 600) {
+  // 1分間物体を検出しなかった場合、待機状態を終える
+  while(measurer->getForwardDistance() > startDistance && count < 600) {
     timer.sleep(100);  // 100ミリ秒スリープ
     count++;
     // 確認用（コマンドラインにセンサの取得値を出力）
     if(count % 50 == 0) {
-      snprintf(buf, SMALL_BUF_SIZE, "count: %d\nbrightness: %d\nforwardDistance: %d", 
-      count, measurer->getBrightness(), measurer->getForwardDistance());
+      snprintf(buf, SMALL_BUF_SIZE, "count: %d\nbrightness: %d\nforwardDistance: %d", count,
+               measurer->getBrightness(), measurer->getForwardDistance());
       logger.log(buf);
     }
   }

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -103,11 +103,12 @@ void Calibrator::measureAndSetTargetBrightness()
   logger.log(buf);
 }
 
-void Calibrator::waitForStart()
+bool Calibrator::waitForStart()
 {
   char buf[SMALL_BUF_SIZE];  // log用にメッセージを一時保持する領域
   Logger logger;
   constexpr int startDistance = 5;  // 手などでスタート合図を出す距離[cm]
+  int count = 0;
 
   logger.log("On standby.\n");
   snprintf(buf, SMALL_BUF_SIZE, "On standby.\n\nSignal within %dcm from Sonar Sensor.",
@@ -115,9 +116,12 @@ void Calibrator::waitForStart()
   logger.log(buf);
 
   // startDistance以内の距離に物体がない間待機する
-  while(measurer.getForwardDistance() > startDistance) {
+  while((measurer.getForwardDistance() > startDistance) && (count < 60000)) {
     timer.sleep();  // 10ミリ秒スリープ
+    count++;
   }
+
+  return count < 60000;
 }
 
 bool Calibrator::getIsLeftCourse()

--- a/module/Calibrator.h
+++ b/module/Calibrator.h
@@ -44,6 +44,7 @@ class Calibrator {
   bool isLeftCourse;     // true:Lコース, false: Rコース
   int targetBrightness;  // 目標輝度
   Timer timer;
+  Measurer* measurer;
 
   /**
    * @brief 左右ボタンでLRコースを選択してisLeftCourseをセットする

--- a/module/Calibrator.h
+++ b/module/Calibrator.h
@@ -25,9 +25,8 @@ class Calibrator {
 
   /**
    * @brief スタート合図が出るまで待機状態にする
-   * @return true:startDistance以内の距離に物体を検出した場合, false:1分間経過した場合
    */
-  bool waitForStart();
+  void waitForStart();
 
   /**
    * @brief isLeftCourseのゲッター

--- a/module/Calibrator.h
+++ b/module/Calibrator.h
@@ -26,7 +26,7 @@ class Calibrator {
   /**
    * @brief スタート合図が出るまで待機状態にする
    */
-  void waitForStart();
+  bool waitForStart();
 
   /**
    * @brief isLeftCourseのゲッター

--- a/module/Calibrator.h
+++ b/module/Calibrator.h
@@ -44,7 +44,6 @@ class Calibrator {
   bool isLeftCourse;     // true:Lコース, false: Rコース
   int targetBrightness;  // 目標輝度
   Timer timer;
-  Measurer measurer;
 
   /**
    * @brief 左右ボタンでLRコースを選択してisLeftCourseをセットする

--- a/module/Calibrator.h
+++ b/module/Calibrator.h
@@ -25,6 +25,7 @@ class Calibrator {
 
   /**
    * @brief スタート合図が出るまで待機状態にする
+   * @return true:startDistance以内の距離に物体を検出した場合, false:1分間経過した場合
    */
   bool waitForStart();
 

--- a/module/EtRobocon2024.cpp
+++ b/module/EtRobocon2024.cpp
@@ -85,7 +85,7 @@ void EtRobocon2024::start()
   // setstate("wait");
   // 合図を送るまで待機する
   while(!calibrator.waitForStart()) {
-    timer.sleep();
+    timer.sleep(100);
     printf("\n\nwait again\n\n");
   }
 

--- a/module/EtRobocon2024.cpp
+++ b/module/EtRobocon2024.cpp
@@ -84,7 +84,7 @@ void EtRobocon2024::start()
   // 走行状態をwait(開始合図待ち)に変更
   // setstate("wait");
   // 合図を送るまで待機する
-  while(!(calibrator.waitForStart())) {
+  while(!calibrator.waitForStart()) {
     timer.sleep();
     printf("\n\nwait again\n\n");
   }

--- a/module/EtRobocon2024.cpp
+++ b/module/EtRobocon2024.cpp
@@ -84,10 +84,7 @@ void EtRobocon2024::start()
   // 走行状態をwait(開始合図待ち)に変更
   // setstate("wait");
   // 合図を送るまで待機する
-  while(!calibrator.waitForStart()) {
-    timer.sleep(100);
-    printf("\n\nwait again\n\n");
-  }
+  calibrator.waitForStart();
 
   AreaMaster LineTraceAreaMaster(Area::LineTrace, isLeftCourse, isLeftEdge, targetBrightness);
   AreaMaster doubleLoopAreaMaster(Area::DoubleLoop, isLeftCourse, isLeftEdge, targetBrightness);

--- a/module/EtRobocon2024.cpp
+++ b/module/EtRobocon2024.cpp
@@ -83,7 +83,8 @@ void EtRobocon2024::start()
   // 走行状態をwait(開始合図待ち)に変更
   // setstate("wait");
   // 合図を送るまで待機する
-  calibrator.waitForStart();
+  while(!(calibrator.waitForStart())) {
+  }
 
   AreaMaster LineTraceAreaMaster(Area::LineTrace, isLeftCourse, isLeftEdge, targetBrightness);
   AreaMaster doubleLoopAreaMaster(Area::DoubleLoop, isLeftCourse, isLeftEdge, targetBrightness);

--- a/module/EtRobocon2024.cpp
+++ b/module/EtRobocon2024.cpp
@@ -52,6 +52,7 @@ void EtRobocon2024::start()
   bool isLeftCourse = true;
   bool isLeftEdge = true;
   Calibrator calibrator;
+  Timer timer;
 
   // 　　　走行ログファイルを取得する場合
   if(shouldGetRunLogs) {
@@ -84,6 +85,8 @@ void EtRobocon2024::start()
   // setstate("wait");
   // 合図を送るまで待機する
   while(!(calibrator.waitForStart())) {
+    timer.sleep();
+    printf("\n\nwait again\n\n");
   }
 
   AreaMaster LineTraceAreaMaster(Area::LineTrace, isLeftCourse, isLeftEdge, targetBrightness);

--- a/module/EtRobocon2024.cpp
+++ b/module/EtRobocon2024.cpp
@@ -52,7 +52,6 @@ void EtRobocon2024::start()
   bool isLeftCourse = true;
   bool isLeftEdge = true;
   Calibrator calibrator;
-  Timer timer;
 
   // 　　　走行ログファイルを取得する場合
   if(shouldGetRunLogs) {


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- module/Calibrator.cpp を変更
    - waitForStart() 関数で１分間物体を認識しなかったら false を返すようにした。
    - measurerを関数ごとにインスタンス化し、関数の終わりで明示的にインスタンスを消去するようにした。
- module/EtRobocon2024.cpp で waitForStart() から false を受け取ったら再び waitForStart() を呼び出すように変更した。

# 動作テスト
- センサーの値が固定されたり、処理がタイムアウトしたりしなくなった。
    - 検証に一回10分かかる以上、検証回数が少ないです。（完全に解決できたとは言いたくない）
- 実行するごとに spike を再起動するようにすると、10分で処理が止まった。

詳しくはこちら
https://www.notion.so/uom-katlab/122dd5b1cc1880a1ad4afb8642da2688?pvs=4

## 添付資料
